### PR TITLE
Add continuous integration using CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,45 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:2.7-stretch
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "requirements.txt" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            pip install --user virtualenv
+            python -m virtualenv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "requirements.txt" }}
+
+      # run tests
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            python -m pytest
+
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports

--- a/ipi/tests/test_interface.py
+++ b/ipi/tests/test_interface.py
@@ -4,8 +4,16 @@
 # i-PI Copyright (C) 2014-2015 i-PI developers
 # See the "licenses" directory for full license information.
 
+import pytest
+try:
+    from ase import build
+    from ase import units
+    from ase.calculators.lj import LennardJones
+    has_ase = True
+except ImportError:
+    has_ase = False
 
-import nose
+
 from ipi.interfaces.sockets import Driver, InterfaceSocket
 from ipi.interfaces.clients import Client, ClientASE
 
@@ -24,16 +32,10 @@ def test_interface():
     """InterfaceSocket: startup."""
     InterfaceSocket()
 
-
+@pytest.mark.skipif(not has_ase, reason='ASE not installed.')
 def test_ASE():
     """Socket client for ASE."""
 
-    try:
-        from ase import build
-        from ase import units
-        from ase.calculators.lj import LennardJones
-    except ImportError:
-        raise nose.SkipTest
 
     # create ASE atoms and calculator
     atoms = build.bulk('Ar', cubic=True)
@@ -44,4 +46,4 @@ def test_ASE():
     atoms.get_potential_energy()
 
     # create the socket client
-    client = ClientASE(atoms, address='ase', _socket=False)
+    ClientASE(atoms, address='ase', _socket=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+pytest
+pytest-mock

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -8,39 +8,40 @@ import os
 import subprocess
 import shlex
 
-from nose import with_setup
-
-FNULL = open(os.devnull, 'w')
+import pytest
 
 
 def run_command(cmd):
     """Runs `cmd` in doc directory."""
     cwd = os.getcwd()
+    f_null = open(os.devnull, 'w')
     os.chdir(os.path.join(os.path.split(__file__)[0], "..", "doc"))
-    ret = subprocess.call(shlex.split(cmd), stdout=FNULL, stderr=FNULL)
+    ret = subprocess.call(shlex.split(cmd), stdout=f_null, stderr=f_null)
+    f_null.close()
     os.chdir(cwd)
     return ret
 
 
+@pytest.fixture
 def distclean():
     """Prepare for documentation build testing."""
     run_command("make distclean")
 
 
+@pytest.fixture
 def clean():
     """Clean up the documentation build after testing."""
+    yield
     run_command("make clean")
 
 
-@with_setup(distclean, None)
-def test_make_aux():
+def test_make_aux(distclean):
     """doc: run make aux"""
     ret = run_command("make aux")
     assert ret == 0
 
 
-@with_setup(None, clean)
-def test_make():
+def test_make(clean):
     """doc: run make"""
     ret = run_command("make")
     assert ret == 0

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -7,8 +7,15 @@
 import os
 import subprocess
 import shlex
+from distutils.spawn import find_executable
 
 import pytest
+
+
+if find_executable('pdflatex') is None or find_executable('bibtex') is None:
+    has_latex = False
+else:
+    has_latex = True
 
 
 def run_command(cmd):
@@ -35,12 +42,14 @@ def clean():
     run_command("make clean")
 
 
+@pytest.mark.skipif(not has_latex, reason='LaTeX not installed.')
 def test_make_aux(distclean):
     """doc: run make aux"""
     ret = run_command("make aux")
     assert ret == 0
 
 
+@pytest.mark.skipif(not has_latex, reason='LaTeX not installed.')
 def test_make(clean):
     """doc: run make"""
     ret = run_command("make")


### PR DESCRIPTION
This is a basic setup of continuous integration on CircleCI. I tested it on my fork and it runs and the tests (that are not skipped) pass.

I also made some minor changes to the tests to avoid the dependence on Nose test (that we're not using anymore) and to skip the manual build tests if LaTeX is not found.