### PR TITLE
  Fixing inputs of examples that still had deprecated motion modes.

### DIFF
--- a/examples/lammps/benz-graph-slc/input.xml
+++ b/examples/lammps/benz-graph-slc/input.xml
@@ -35,7 +35,7 @@
   </prng>
   <system>
     <motion mode='dynamics'>
-      <dynamics mode='mts'>
+      <dynamics mode='nvt'>
         <timestep units='femtosecond'> 0.10 </timestep>
         <thermostat mode='pile_l'>
           <tau units='femtosecond'>100</tau>

--- a/examples/lammps/h2o-bias/input.xml
+++ b/examples/lammps/h2o-bias/input.xml
@@ -21,7 +21,7 @@
          <force forcefield ="lmpserial1" > </force>
       </forces> 
       <motion mode="dynamics">
-         <dynamics mode="mts">
+         <dynamics mode="nvt">
             <timestep units="femtosecond"> 0.25 </timestep>
             <thermostat mode="langevin">
                 <tau units="femtosecond"> 100 </tau>


### PR DESCRIPTION
Some examples had deprecated options. Fixed. Would be excellent to have an automatic check to see if all inputs run so that we minimize broken examples!