### PR TITLE
This fix the output of the temperature when len(fixatoms)>0

### DIFF
--- a/ipi/engine/properties.py
+++ b/ipi/engine/properties.py
@@ -778,18 +778,24 @@ class Properties(dobject):
 
         if len(self.motion.fixatoms) > 0:
             for i in self.motion.fixatoms:
-                pi = np.tile(np.sqrt(self.beads.m[i] * Constants.kb * self.ensemble.temp), 3)
+                pi = np.tile(np.sqrt(self.beads.m[i] * Constants.kb * self.ensemble.temp * self.beads.nbeads), 3)
                 self.beads.p[:, 3 * i:3 * i + 3] += pi
 
         if self.motion.fixcom:
             # Adds a fake momentum to the centre of mass. This is the easiest way
             # of getting meaningful temperatures for subsets of the system when there
             # are fixed components
-            M = np.sum(self.beads.m3) / 3.0 / self.beads.nbeads
-            pcm = np.tile(np.sqrt(M * Constants.kb * self.ensemble.temp), 3)
+            M = np.sum(self.beads.m) 
+            pcm = np.tile(np.sqrt(M * Constants.kb * self.ensemble.temp * self.beads.nbeads), 3)
             vcm = np.tile(pcm / M, self.beads.natoms)
 
             self.beads.p += self.beads.m3 * vcm
+
+            #Avoid double counting
+            if len(self.motion.fixatoms) > 0:
+                for i in self.motion.fixatoms:
+                    self.beads.p[:, 3 * i:3 * i + 3] -= np.multiply(self.beads.m[i] , pcm/M )
+
 
         kemd, ncount = self.get_kinmd(atom, bead, nm, return_count=True)
 


### PR DESCRIPTION
The get_temp function inside properties.py had a bug when "len(fixatoms)>0".
Additionally, there was a double counting when "len(fixatoms)>0 and fixcom=True "
Now both things are fixed.