### PR TITLE
Making geop work without unnecessary force calls again 

### DIFF
--- a/ipi/engine/forces.py
+++ b/ipi/engine/forces.py
@@ -738,6 +738,7 @@ class Forces(dobject):
                 dfkbref = dd(mreff._forces[b])
                 dfkbself = dd(mself._forces[b])
                 dfkbself.ufvx.set(deepcopy(dfkbref.ufvx._value), manual=False)
+                dfkbself.ufvx.taint(taintme=False)
 
     def run(self):
         """Makes the socket start looking for driver codes.


### PR DESCRIPTION
   Explicitly untainting forces in the transfer_force routine so that
  the behavior is back to where it should be. Seems that it was wrong
  since December 22, 2017. This is the commit that caused it:

  "commit 67eb6b1e3a9c034069a0014f50168f1033e3a7af
  Author: Michele Ceriotti <michele.ceriotti@gmail.com>
  Date:   Sat Aug 26 09:00:01 2017 +0200

   Added threadlocks to depend object to avoid concurrent tampering of depend chains by different threads

  diff --git a/ipi/utils/depend.py b/ipi/utils/depend.py
  --- a/ipi/utils/depend.py
  +++ b/ipi/utils/depend.py
  @@ -336,4 +342,1 @@
  "-        self._value = value"
  "-        self.taint(taintme=False)"
  "-        if manual:"
  "-            self.update_man()"
  "+            #self.taint(taintme=False)"

  Because this had a purpose for the threading infrastructure we decided for now not to revert these lines.
  What we do now could break threading with geop, but we hope this is never used...