### PR TITLE
  Same PR as in the py2 version:

### DIFF
--- a/ipi/engine/motion/dynamics.py
+++ b/ipi/engine/motion/dynamics.py
@@ -19,6 +19,7 @@ from ipi.engine.motion import Motion
 from ipi.utils.depend import *
 from ipi.engine.thermostats import Thermostat
 from ipi.engine.barostats import Barostat
+from ipi.utils.softexit import softexit
 
 
 #__all__ = ['Dynamics', 'NVEIntegrator', 'NVTIntegrator', 'NPTIntegrator', 'NSTIntegrator', 'SCIntegrator`']
@@ -67,6 +68,8 @@ class Dynamics(Motion):
         if thermostat is None:
             self.thermostat = Thermostat()
         else:
+            if (thermostat.__class__.__name__ is ("ThermoPILE_G" or "ThermoNMGLEG ")) and (len(fixatoms)>0):
+                softexit.trigger("!! Sorry, fixed atoms and global thermostat on the centroid not supported. Use a local thermostat. !!")
             self.thermostat = thermostat
 
         if nmts is None or len(nmts) == 0:

--- a/ipi/engine/thermostats.py
+++ b/ipi/engine/thermostats.py
@@ -492,8 +492,10 @@ class ThermoPILE_G(ThermoPILE_L):
         # centroid thermostat
         self._thermos[0] = ThermoSVR(temp=1, dt=1, tau=1)
 
+        fixdof0 = fixdof / nm.nbeads # an ugly fix to the combination of PILE_G with fixed atoms.
+
         t = self._thermos[0]
-        t.bind(pm=(nm.pnm[0, :], nm.dynm3[0, :]), prng=self.prng, fixdof=fixdof)
+        t.bind(pm=(nm.pnm[0, :], nm.dynm3[0, :]), prng=self.prng, fixdof=fixdof0)
         dpipe(dself.temp, dd(t).temp)
         dpipe(dself.dt, dd(t).dt)
         dpipe(dself.tau, dd(t).tau)

--- a/ipi/engine/thermostats.py
+++ b/ipi/engine/thermostats.py
@@ -492,10 +492,8 @@ class ThermoPILE_G(ThermoPILE_L):
         # centroid thermostat
         self._thermos[0] = ThermoSVR(temp=1, dt=1, tau=1)
 
-        fixdof0 = fixdof / nm.nbeads # an ugly fix to the combination of PILE_G with fixed atoms.
-
         t = self._thermos[0]
-        t.bind(pm=(nm.pnm[0, :], nm.dynm3[0, :]), prng=self.prng, fixdof=fixdof0)
+        t.bind(pm=(nm.pnm[0, :], nm.dynm3[0, :]), prng=self.prng, fixdof=fixdof)
         dpipe(dself.temp, dd(t).temp)
         dpipe(dself.dt, dd(t).dt)
         dpipe(dself.tau, dd(t).tau)

--- a/ipi/inputs/motion/motion.py
+++ b/ipi/inputs/motion/motion.py
@@ -24,6 +24,7 @@ Classes:
 import numpy as np
 from copy import copy
 import ipi.engine.initializer
+from ipi.utils.softexit import softexit
 
 from ipi.engine.motion import Motion, Dynamics, ConstrainedDynamics, Replay, GeopMotion, NEBMover,\
     DynMatrixMover, MultiMotion, AlchemyMC, InstantonMotion,\
@@ -171,7 +172,7 @@ class InputMotionBase(Input):
             raise ValueError("Cannot store Mover calculator of type " + str(type(sc)))
 
         if (sc.fixcom is True) and (len(sc.fixatoms) > 0):
-            raise ValueError("Fixed atoms break translational invariance, and so should be used with <fixcom> False </fixcom>. You can disable this error if you know what you are doing.")
+            softexit.trigger("Fixed atoms break translational invariance, and so should be used with <fixcom> False </fixcom>. You can disable this error if you know what you are doing.")
 
         if tsc == 0:
             self.file.store(sc.intraj)

--- a/ipi/inputs/motion/motion.py
+++ b/ipi/inputs/motion/motion.py
@@ -170,6 +170,9 @@ class InputMotionBase(Input):
         else:
             raise ValueError("Cannot store Mover calculator of type " + str(type(sc)))
 
+        if (sc.fixcom is True) and (len(sc.fixatoms) > 0):
+            raise ValueError("Fixed atoms break translational invariance, and so should be used with <fixcom> False </fixcom>. You can disable this error if you know what you are doing.")
+
         if tsc == 0:
             self.file.store(sc.intraj)
         elif tsc > 0:


### PR DESCRIPTION
  Fixing bug in the combination of fixed atoms and pile_g
  and issuing a warning/stop that fixed atoms and fixcom should
  not be used together.