### PR TITLE
Makes sure checkpoint step is output correctly in RESTART files

### DIFF
--- a/ipi/engine/outputs.py
+++ b/ipi/engine/outputs.py
@@ -449,7 +449,7 @@ class CheckpointOutput(dobject):
         """
 
         self.filename = filename
-        self.step = step
+        self.step = depend_value(name="step", value=step)
         self.stride = stride
         self.overwrite = overwrite
         self._storing = False


### PR DESCRIPTION
Not as a trivial fix as one would expect. Nice side effect is that dobjects should now deepcopy() correctly