### PR TITLE
Python 3.9 compatibility by replacing deprecated Thread.isAlive() with Thread.is_alive()

### DIFF
--- a/ipi/engine/motion/al6xxx_kmc.py
+++ b/ipi/engine/motion/al6xxx_kmc.py
@@ -425,7 +425,7 @@ class AlKMC(Motion):
         ):  # if all evaluators are busy, wait for one to get free
             for st in ethreads:
                 st.join(1e-2)
-                if st is None or not st.isAlive():
+                if st is None or not st.is_alive():
                     break
         with self._threadlock:
             # finds free evaluator
@@ -599,7 +599,7 @@ class AlKMC(Motion):
                 levents.append(nevent)
         # wait for all evaluators to finish
         for st in ethreads:
-            while st is not None and st.isAlive():
+            while st is not None and st.is_alive():
                 st.join(2)
 
         print(

--- a/ipi/interfaces/sockets.py
+++ b/ipi/interfaces/sockets.py
@@ -677,7 +677,7 @@ class InterfaceSocket(object):
                 self.clients.remove(c)
                 # requeue jobs that have been left hanging
                 for [k, j, tc] in self.jobs[:]:
-                    if tc.isAlive():
+                    if tc.is_alive():
                         tc.join(2)
                     if j is c:
                         self.jobs = [
@@ -862,7 +862,7 @@ class InterfaceSocket(object):
         """
 
         if r["status"] == "Done":
-            while ct.isAlive():  # we can wait for end of thread
+            while ct.is_alive():  # we can wait for end of thread
                 ct.join()
             self.jobs = [
                 w for w in self.jobs if not (w[0] is r and w[1] is c)


### PR DESCRIPTION
Dear ladies and gentlemen,
currently I-PI is not compatible with Python 3.9+, as in 3.9 Thread.isAlive() was finally [deprecated](https://bugs.python.org/issue37804) in favor of Thread.is_alive(). This (very) small PR updates the four remaining occurrences of isAlive() to is_alive().

All the best,
Johannes