### PR TITLE
Softexit status

### DIFF
--- a/bin/i-pi
+++ b/bin/i-pi
@@ -67,7 +67,7 @@ def main(fn_input, options):
     # TODO: Have them written when simulation.run() finishes instead.
     # It should be sufficient to run `self.softexit() at the end of
     # `Simulation.run()`. Anything else missing?
-    softexit.trigger(" @ SIMULATION: Exiting cleanly.")
+    softexit.trigger(status="success", message=" @ SIMULATION: Exiting cleanly.")
 
 
 if __name__ == '__main__':

--- a/ipi/engine/forces.py
+++ b/ipi/engine/forces.py
@@ -178,7 +178,9 @@ class ForceBead(dobject):
                 # if we return, we may as well output wrong numbers, or mess up things.
                 # so we can only call soft-exit and wait until that is done. then kill the thread
                 # we are in.
-                softexit.trigger(" @ FORCES : cannot return so will die off here")
+                softexit.trigger(
+                    message=" @ FORCES : cannot return so will die off here"
+                )
                 while softexit.exiting:
                     time.sleep(self.ff.latency)
                 sys.exit()

--- a/ipi/engine/motion/dynamics.py
+++ b/ipi/engine/motion/dynamics.py
@@ -80,7 +80,8 @@ class Dynamics(Motion):
                 thermostat.__class__.__name__ is ("ThermoPILE_G" or "ThermoNMGLEG ")
             ) and (len(fixatoms) > 0):
                 softexit.trigger(
-                    "!! Sorry, fixed atoms and global thermostat on the centroid not supported. Use a local thermostat. !!"
+                    status="bad",
+                    message="!! Sorry, fixed atoms and global thermostat on the centroid not supported. Use a local thermostat. !!",
                 )
             self.thermostat = thermostat
 

--- a/ipi/engine/motion/geop.py
+++ b/ipi/engine/motion/geop.py
@@ -157,14 +157,18 @@ class GeopMotion(Motion):
 
         if len(self.fixatoms) == len(self.beads[0]):
             softexit.trigger(
-                "WARNING: all atoms are fixed, geometry won't change. Exiting simulation"
+                status="bad",
+                message="WARNING: all atoms are fixed, geometry won't change. Exiting simulation",
             )
 
     def step(self, step=None):
         if self.optimizer.converged:
             # if required, exit upon convergence. otherwise just return without action
             if self.conv_exit:
-                softexit.trigger("Geometry optimization converged. Exiting simulation")
+                softexit.trigger(
+                    status="success",
+                    message="Geometry optimization converged. Exiting simulation",
+                )
             else:
                 info(
                     "Convergence threshold met. Will carry on but do nothing.",
@@ -612,10 +616,6 @@ class LBFGSOptimizer(DummyOptimizer):
         self.gm.bind(self)
         self.big_step = geop.big_step
         self.ls_options = geop.ls_options
-
-        # if len(self.fixatoms) > 0:
-        #     softexit.trigger("The L-BFGS optimization with fixatoms is implemented, but seems to be unstable. "
-        #                      "We stop here. Comment this line and continue only if you know what you are doing.")
 
         if geop.qlist.size != (self.corrections * self.beads.q.size):
             if geop.qlist.size == 0:

--- a/ipi/engine/motion/instanton.py
+++ b/ipi/engine/motion/instanton.py
@@ -391,7 +391,9 @@ class GradientMapper(object):
             try:
                 from scipy.interpolate import interp1d
             except ImportError:
-                softexit.trigger("Scipy required to use  max_ms >0")
+                softexit.trigger(
+                    status="bad", message="Scipy required to use  max_ms >0"
+                )
 
             indexes = list()
             indexes.append(0)
@@ -410,7 +412,8 @@ class GradientMapper(object):
             )
             if len(indexes) <= 2:
                 softexit.trigger(
-                    "Too few beads fulfill criteria. Please reduce max_ms or max_e"
+                    status="bad",
+                    message="Too few beads fulfill criteria. Please reduce max_ms or max_e",
                 )
         else:
             indexes = np.arange(self.dbeads.nbeads)
@@ -921,13 +924,19 @@ class DummyOptimizer(dobject):
         """General tasks that have to be performed before actual step"""
 
         if self.exit:
-            softexit.trigger("Geometry optimization converged. Exiting simulation")
+            softexit.trigger(
+                status="success",
+                message="Geometry optimization converged. Exiting simulation",
+            )
 
         if not self.init:
             self.initialize(step)
 
         if adaptative:
-            softexit.trigger("Adaptative discretization is not fully implemented")
+            softexit.trigger(
+                status="bad",
+                message="Adaptative discretization is not fully implemented",
+            )
             # new_coef = <implement_here>
             # self.im.set_coef(coef)
             # self.gm.set_coef(coef)

--- a/ipi/engine/motion/phonons.py
+++ b/ipi/engine/motion/phonons.py
@@ -112,7 +112,10 @@ class DynMatrixMover(Motion):
             self.phcalc.transform()
             self.refdynmatrix = self.apply_asr(self.refdynmatrix.copy())
             self.printall(self.prefix, self.refdynmatrix.copy(), fixdof=self.fixdof)
-            softexit.trigger("Dynamic matrix is calculated. Exiting simulation")
+            softexit.trigger(
+                status="success",
+                message="Dynamic matrix is calculated. Exiting simulation",
+            )
 
     def printall(self, prefix, dmatx, deltaw=0.0, fixdof=np.array([])):
         """Prints out diagnostics for a given dynamical matrix."""

--- a/ipi/engine/motion/replay.py
+++ b/ipi/engine/motion/replay.py
@@ -113,7 +113,7 @@ class Replay(Motion):
                     "the number of files should be equal to the number of beads.",
                     verbosity.low,
                 )
-                softexit.trigger(" # Error in replay input.")
+                softexit.trigger(status="bad", message=" # Error in replay input.")
         while True:
             self.rstep += 1
             try:
@@ -149,12 +149,16 @@ class Replay(Motion):
                     mycell = simchk.cell.fetch()
                     mybeads = simchk.beads.fetch()
                     self.beads.q[:] = mybeads.q
-                    softexit.trigger(" # Read single checkpoint")
+                    softexit.trigger(
+                        status="success", message=" # Read single checkpoint"
+                    )
                 # do not assign cell if it contains an invalid value (typically missing cell in the input)
                 if mycell.V > 0:
                     self.cell.h[:] = mycell.h
             except EOFError:
-                softexit.trigger(" # Finished reading re-run trajectory")
+                softexit.trigger(
+                    status="success", message=" # Finished reading re-run trajectory"
+                )
             if (step is None) or (self.rstep > step):
                 break
 

--- a/ipi/engine/motion/scphonons.py
+++ b/ipi/engine/motion/scphonons.py
@@ -40,7 +40,7 @@ except ImportError as e:
 
 class SCPhononsMover(Motion):
     """
-    Self consistent phonons method.
+    Self-consistent phonons method.
     """
 
     def __init__(
@@ -189,7 +189,8 @@ class SCPhononsMover(Motion):
     def step(self, step=None):
         if self.isc == self.max_iter:
             softexit.trigger(
-                " @SCP: Reached maximum iterations. Terminating the SCP calculation."
+                status="bad",
+                message=" @SCP: Reached maximum iterations. Terminating the SCP calculation.",
             )
         if self.imc == 0:
             self.phononator.reset()

--- a/ipi/engine/motion/vscf.py
+++ b/ipi/engine/motion/vscf.py
@@ -754,7 +754,9 @@ class IMF(DummyCalculator):
             " @NM: ALL QUANTITIES PER PRIMITIVE UNIT CELL (WHERE APPLICABLE) \n",
             verbosity.low,
         )
-        softexit.trigger(" @NM: The IMF calculation has terminated.")
+        softexit.trigger(
+            status="success", message=" @NM: The IMF calculation has terminated."
+        )
 
 
 class VSCF(IMF):
@@ -864,7 +866,7 @@ class VSCF(IMF):
             self.evecs_vscf = np.zeros((self.dof, self.nbasis, self.nbasis))
 
     def step(self, step=None):
-        """Computes the Born Oppenheimer curve along a normal mode."""
+        """Computes the Born-Oppenheimer curve along a normal mode."""
 
         # Performs some basic initialization.
         if step == 0:
@@ -1498,4 +1500,6 @@ class VSCF(IMF):
         Triggers a soft exit.
         """
 
-        softexit.trigger(" @NM: The VSCF calculation has terminated.")
+        softexit.trigger(
+            status="success", message=" @NM: The VSCF calculation has terminated."
+        )

--- a/ipi/inputs/motion/motion.py
+++ b/ipi/inputs/motion/motion.py
@@ -282,7 +282,8 @@ class InputMotionBase(Input):
 
         if (sc.fixcom is True) and (len(sc.fixatoms) > 0):
             softexit.trigger(
-                "Fixed atoms break translational invariance, and so should be used with <fixcom> False </fixcom>. You can disable this error if you know what you are doing."
+                status="bad",
+                message="Fixed atoms break translational invariance, and so should be used with <fixcom> False </fixcom>. You can disable this error if you know what you are doing.",
             )
 
         if tsc == 0:

--- a/ipi/utils/softexit.py
+++ b/ipi/utils/softexit.py
@@ -158,7 +158,7 @@ class Softexit(object):
             " @SOFTEXIT:   Kill signal. Trying to make a clean exit.", verbosity.low
         )
 
-        self.trigger(" @SOFTEXIT: Kill signal received")
+        self.trigger(status="restartable", message=" @SOFTEXIT: Kill signal received")
 
         try:
             self.__del__()
@@ -173,11 +173,16 @@ class Softexit(object):
         while self._doloop[0]:
             time.sleep(SOFTEXITLATENCY)
             if os.path.exists("EXIT"):
-                self.trigger(" @SOFTEXIT: EXIT file detected.")
+                self.trigger(
+                    status="restartable", message=" @SOFTEXIT: EXIT file detected."
+                )
                 break
 
             if self.timeout > 0 and self.timeout < time.time():
-                self.trigger(" @SOFTEXIT: Maximum wallclock time elapsed.")
+                self.trigger(
+                    status="restartable",
+                    message=" @SOFTEXIT: Maximum wallclock time elapsed.",
+                )
                 break
 
 

--- a/ipi/utils/softexit.py
+++ b/ipi/utils/softexit.py
@@ -66,13 +66,15 @@ class Softexit(object):
 
         self.tlist.append((thread, loop_control))
 
-    def trigger(self, message=""):
+    def trigger(self, status="restartable", message=""):
         """Halts the simulation.
 
         Prints out a warning message, then runs all the exit functions in flist
         before terminating the simulation.
 
         Args:
+           status: which kind of stop it is: simulation restartable as is,
+                   successful finish or aborted because of some problem.
            message: The message to output to standard output.
         """
 
@@ -81,13 +83,21 @@ class Softexit(object):
             self.exiting = True
             self.triggered = True
 
-            if message != "":
-                warning(
-                    "Soft exit has been requested with message: '"
-                    + message
-                    + "'. Cleaning up.",
-                    verbosity.low,
-                )
+            if status == "restartable":
+                message += "\nRestartable as is: YES."
+            elif status == "success":
+                message += "\nI-PI reports success. Restartable as is: NO."
+            elif status == "bad":
+                message += "\nI-PI reports a problem. Restartable as is: NO."
+            else:
+                raise ValueError("Unknown option for softexit status.")
+
+            warning(
+                "Soft exit has been requested with message: '"
+                + message
+                + "'. Cleaning up.",
+                verbosity.low,
+            )
 
             # calls all the registered emergency softexit procedures
             for f in self.flist:


### PR DESCRIPTION
Now developers can specify whether the simulation is restartable "as is" after particular softexit, or ended with success, or aborted with a problem. Default is "restartable". The only difference is the message that will be printed when exiting.

I added this new option to trigger() calls throughout the code. The only place where it's unclear which status to set is in `forces.py`. It is unclear what `if self.request["status"] == "Exit"` can mean: it can be restartable or it can indicate some problem in client code. I put "restartable" for now, but it can also be misleading in bad cases.