### PR TITLE
Removed virial from harm3d potential in driver.f90. 

### DIFF
--- a/drivers/f90/driver.f90
+++ b/drivers/f90/driver.f90
@@ -472,15 +472,11 @@
             ELSEIF (vstyle == 30) THEN ! 3D harmonic potential
                    pot = 0.0d0
                    forces = 0.0d0
-                   virial = 0.0d0
                DO i=1,nat 
                    pot = pot + 0.5*ks*atoms(i,1)**2 + 0.5*ks*atoms(i,2)**2 + 0.5*ks*atoms(i,3)**2
                    forces(i,1) = -ks*atoms(i,1)
                    forces(i,2) = -ks*atoms(i,2)
                    forces(i,3) = -ks*atoms(i,3)
-                   virial(i,1) = forces(i,1)*atoms(i,1)
-                   virial(i,2) = forces(i,2)*atoms(i,2)
-                   virial(i,3) = forces(i,3)*atoms(i,3)
                 enddo
             ELSEIF (vstyle == 7) THEN ! linear potential in x position of the 1st atom
                pot = ks*atoms(1,1)


### PR DESCRIPTION
Hi guys, 
Working on a new (much faster) implementation for bosonic PIMD, in preparation for our tutorial in the CECAM school.
Along the way, made a minor change here. I deleted the virial from harm3d potential.
It is not mandatory and had invalid memory access for more than three particles.
Barak
