### PR TITLE
Bugfix: column number in output of properties with size 1

### DIFF
--- a/ipi/engine/outputs.py
+++ b/ipi/engine/outputs.py
@@ -190,15 +190,16 @@ class PropertyOutput(BaseOutput):
             key = getkey(what)
             prop = self.system.properties.property_dict[key]
 
-            if "size" in prop:
+            if "size" not in prop or prop["size"] == 1:
+                ohead += "column %3d    " % (icol)
+                icol += 1
+            else:
                 if (type(prop["size"]) is str) or (prop["size"] <= 0):
                     raise RuntimeError("ERROR: property %s has undefined size." % key)
                 elif prop["size"] > 1:
                     ohead += "cols.  %3d-%-3d" % (icol, icol + prop["size"] - 1)
                     icol += prop["size"]
-            else:
-                ohead += "column %3d    " % (icol)
-                icol += 1
+
             ohead += " --> %s " % (what)
             if "help" in prop:
                 ohead += ": " + prop["help"]


### PR DESCRIPTION
Hi,

A small fix to print in the header also the column number of properties that specify size, but that size is 1. An example is the property virial_fq. 

Previously the result was a line "# column --> virial_fq : The scalar product of force and position.", and now it should be something like # column 7 --> virial_fq : The scalar product of force and position.", including the column number. 

This is useful for scripts that parse the output according to the headers, akin to the code in [getproperty.py](https://github.com/i-pi/i-pi/blob/master/tools/py/getproperty.py).