### PR TITLE
Bosonic PIMD in quadratic time

### DIFF
--- a/drivers/f90/driver.f90
+++ b/drivers/f90/driver.f90
@@ -479,7 +479,13 @@
                    forces(i,2) = -ks*atoms(i,2)
                    forces(i,3) = -ks*atoms(i,3)
                    virial(1,1) = virial(1,1) + forces(i,1)*atoms(i,1)
+                   virial(1,2) = virial(1,2) + forces(i,1)*atoms(i,2)
+                   virial(1,3) = virial(1,3) + forces(i,1)*atoms(i,3)
+                   virial(2,1) = virial(2,1) + forces(i,2)*atoms(i,1)
                    virial(2,2) = virial(2,2) + forces(i,2)*atoms(i,2)
+                   virial(2,3) = virial(2,3) + forces(i,2)*atoms(i,3)
+                   virial(3,1) = virial(3,1) + forces(i,3)*atoms(i,1)
+                   virial(3,2) = virial(3,2) + forces(i,3)*atoms(i,2)
                    virial(3,3) = virial(3,3) + forces(i,3)*atoms(i,3)
                 enddo
             ELSEIF (vstyle == 7) THEN ! linear potential in x position of the 1st atom

--- a/drivers/f90/driver.f90
+++ b/drivers/f90/driver.f90
@@ -479,13 +479,7 @@
                    forces(i,2) = -ks*atoms(i,2)
                    forces(i,3) = -ks*atoms(i,3)
                    virial(1,1) = virial(1,1) + forces(i,1)*atoms(i,1)
-                   virial(1,2) = virial(1,2) + forces(i,1)*atoms(i,2)
-                   virial(1,3) = virial(1,3) + forces(i,1)*atoms(i,3)
-                   virial(2,1) = virial(2,1) + forces(i,2)*atoms(i,1)
                    virial(2,2) = virial(2,2) + forces(i,2)*atoms(i,2)
-                   virial(2,3) = virial(2,3) + forces(i,2)*atoms(i,3)
-                   virial(3,1) = virial(3,1) + forces(i,3)*atoms(i,1)
-                   virial(3,2) = virial(3,2) + forces(i,3)*atoms(i,2)
                    virial(3,3) = virial(3,3) + forces(i,3)*atoms(i,3)
                 enddo
             ELSEIF (vstyle == 7) THEN ! linear potential in x position of the 1st atom

--- a/examples/bosons/input.xml
+++ b/examples/bosons/input.xml
@@ -1,0 +1,61 @@
+<!--REGTEST 
+COMMAND(4)    i-pi-driver -u -h REGTEST_SOCKET -m harm3d -o 1.21647924E-8
+ ENDREGTEST-->
+<simulation threading='False' verbosity='low'>
+
+   <ffsocket mode='unix' name='driver'>
+       <address>localhost</address>
+   </ffsocket>
+   
+   <total_steps> 100 </total_steps>
+
+   <output prefix="data">
+      <trajectory stride="100" filename="pos" cell_units="angstrom">positions{angstrom}</trajectory>
+      <!--<trajectory stride="1" filename="xc" format="xyz">x_centroid{angstrom}</trajectory>-->
+      <properties stride="100"> [ step, time{femtosecond}, conserved, temperature{kelvin}, kinetic_cv, 
+            potential, virial_fq ] </properties>
+   </output>
+
+   <prng>
+      <seed> 18885 </seed>
+   </prng>
+
+   <system>
+
+      <forces> 
+          <force forcefield="driver"></force>
+      </forces>
+
+      <initialize nbeads="32">
+        <positions mode="manual" bead="0"> [78, -21, 58, 17, -84, -93, 52, -56, -13] </positions>
+	<masses mode="manual"> [1.0, 1.0, 1.0] </masses>
+	<labels mode="manual"> ['E', 'E', 'E'] </labels>
+        <cell>
+         [   2500, 0, 0, 0, 2500, 0, 0, 0, 2500 ]
+        </cell>
+	<velocities mode='thermal' units='kelvin'> 17.4 </velocities>
+      </initialize>
+
+      <normal_modes propagator='bab'>
+	      <nmts> 10 </nmts>
+	      <bosons> [0, 1, 2] </bosons>
+      </normal_modes>
+
+      <ensemble>
+         <temperature units="kelvin"> 17.4 </temperature>
+      </ensemble>
+
+      <motion mode="dynamics">
+	<fixcom> False </fixcom>
+        <dynamics mode="nvt">
+         <timestep units="femtosecond"> 1 </timestep>
+  	  <thermostat mode='pile_l'>
+		<tau units='femtosecond'>100</tau>
+	  </thermostat>
+
+        </dynamics>
+      </motion>
+
+  </system>
+
+</simulation>

--- a/ipi/engine/normalmodes.py
+++ b/ipi/engine/normalmodes.py
@@ -712,13 +712,13 @@ class NormalModes(dobject):
         if len(self.bosons) == 0:
             return
 
-        boson_mass = dstrip(self.beads.m)[self.bosons[0]] # take mass of first boson
+        boson_mass = dstrip(self.beads.m)[self.bosons[0]]  # take mass of first boson
         betaP = 1.0 / (self.nbeads * units.Constants.kb * self.ensemble.temp)
         # positions of only the boson atoms
         q = self.beads.q.reshape((self.nbeads, self.natoms, 3))[:, self.bosons, :]
-        exchange_potential = ExchangePotential(self.bosons, q,
-                                               self.nbeads, boson_mass,
-                                               self.omegan2, betaP)
+        exchange_potential = ExchangePotential(
+            self.bosons, q, self.nbeads, boson_mass, self.omegan2, betaP
+        )
         return exchange_potential.get_vspring_and_fspring()
 
     def get_fspring(self):

--- a/ipi/utils/exchange.py
+++ b/ipi/utils/exchange.py
@@ -84,7 +84,7 @@ class ExchangePotential(dobject):
 
     def _evaluate_cycle_energies(self):
         """
-        Evaluate all the cycle energies, as outlined in Eqs. 5-7 of the paper.
+        Evaluate all the cycle energies, as outlined in Eqs. 5-7 of arXiv:2305.18025.
         Returns an upper-triangular matrix, Emks[u,v] is the ring polymer energy of the cycle on u,...,v.
         """
         # using column-major (Fortran order) because uses of the array are mostly within the same column
@@ -122,7 +122,7 @@ class ExchangePotential(dobject):
 
     def _evaluate_prefix_V(self):
         """
-        Evaluate V^[1,1], V^[1,2], ..., V^[1,N], as outlined in Eq. 3 of the paper.
+        Evaluate V^[1,1], V^[1,2], ..., V^[1,N], as outlined in Eq. 3 of arXiv:2305.18025.
         (In the code, particle indices start from 0.)
         Returns a vector of these potentials, in this order.
         Assumes that the cycle energies self._E_from_to have been computed.
@@ -147,7 +147,7 @@ class ExchangePotential(dobject):
 
     def _evaluate_suffix_V(self):
         """
-        Evaluate V^[1,N], V^[2,N], ..., V^[N,N], as outlined in Eq. 16 of the paper.
+        Evaluate V^[1,N], V^[2,N], ..., V^[N,N], as outlined in Eq. 16 of arXiv:2305.18025.
         (In the code, particle indices start from 0.)
         Returns a vector of these potentials, in this order.
         Assumes that both the cycle energies self._E_from_to and prefix potentials self._V have been computed.
@@ -177,7 +177,7 @@ class ExchangePotential(dobject):
 
     def evaluate_spring_forces(self):
         """
-        Evaluate the ring polymer forces on all the beads, as outlined in Eq. 13, 17-18 of the paper.
+        Evaluate the ring polymer forces on all the beads, as outlined in Eq. 13, 17-18 of arXiv:2305.18025.
         (In the code, particle indices start from 0.)
         Returns an array, F[j, l, :] is the force (3d vector) on bead j of particle l.
         Assumes that both the cycle energies self._E_from_to, the prefix potentials self._V,

--- a/ipi/utils/exchange.py
+++ b/ipi/utils/exchange.py
@@ -90,9 +90,9 @@ class ExchangePotential(dobject):
         # using column-major (Fortran order) because uses of the array are mostly within the same column
         Emks = np.zeros((self._N, self._N), dtype=float, order="F")
 
-        intra_spring_energies = np.sum(self._bead_diff_intra ** 2, axis=(0, -1))
+        intra_spring_energies = np.sum(self._bead_diff_intra**2, axis=(0, -1))
         spring_energy_first_last_bead_array = np.sum(
-            self._bead_diff_inter_first_last_bead ** 2, axis=-1
+            self._bead_diff_inter_first_last_bead**2, axis=-1
         )
 
         # for m in range(self._N):

--- a/ipi/utils/exchange.py
+++ b/ipi/utils/exchange.py
@@ -5,7 +5,6 @@ Used in /engine/normalmodes.py
 # This file is part of i-PI.
 # i-PI Copyright (C) 2014-2015 i-PI developers
 # See the "licenses" directory for full license information.
-from ipi.utils import units
 from ipi.utils.depend import *
 
 import numpy as np


### PR DESCRIPTION
Version of bosonic PIMD for the PIQM 2023 CECAM School at Tel Aviv University:

This is an improvement of the bosonic PIMD implementation (Hirshberg et al., PNAS 2019), with an algorithm that scales quadratically rather than cubically. It generates the same potential, forces, and trajectories as before, up to floating point differences, only faster. This is the version of the code that we plan to use for the CECAM tutorial in Tel Aviv. @BarakHirshberg

We added an automatic test for 3 particles, similar to the existing regression tests.
The documentation of the feature is unchanged.

We tested the code with 4 bosons, 3 bosons, 3 distinguishable particles (but with the same integrator used for bosons), and a mixture of 2 bosons and one distinguishable, all in a harmonic trap, and validated the energy against the analytical result.