### PR TITLE
Fix atom index mapping in atomswap class

### DIFF
--- a/ipi/engine/motion/atomswap.py
+++ b/ipi/engine/motion/atomswap.py
@@ -114,7 +114,7 @@ class AtomSwap(Motion):
             # map the "subset" indices back to the "absolute" atom indices
             i = axlist[i]
             j = axlist[j]
-            
+
             old_energy = self.forces.pot
             # swap the atom positions
             self.dbeads.q[:] = self.beads.q[:]

--- a/ipi/engine/motion/atomswap.py
+++ b/ipi/engine/motion/atomswap.py
@@ -111,6 +111,10 @@ class AtomSwap(Motion):
             while self.beads.names[axlist[i]] == self.beads.names[axlist[j]]:
                 j = self.prng.rng.randint(lenlist)  # makes sure we pick a real exchange
 
+            # map the "subset" indices back to the "absolute" atom indices
+            i = axlist[i]
+            j = axlist[j]
+            
             old_energy = self.forces.pot
             # swap the atom positions
             self.dbeads.q[:] = self.beads.q[:]


### PR DESCRIPTION
Indices of the selected subsets were not mapped back to the atom indices before the swap. 
This affects the trajectory - but not the converged observables - for simulations that swap all with all, but messes up completely the case in which only a subset is actually considered. 