### PR TITLE
Fixing flake8 version for yet another github stupidity

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,5 @@ jobs:
         uses: rbialon/flake8-annotations@v1
       - name: flake8 for syntax
         run: |
-           python -m pip install importlib-metadata==4.12.0
-           python -m pip install flake8==3.8.4  
+           python -m pip install flake8==6.1.0  
            flake8 --select=F --ignore= --ignore=F403,F405 --per-file-ignores=**__init__.py:F401 --statistics

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,6 @@ jobs:
         uses: rbialon/flake8-annotations@v1
       - name: flake8 for syntax
         run: |
-           python -m pip install importlib-metadata==4.13.0
+           python -m pip install importlib-metadata==4.12.0
            python -m pip install flake8==3.8.4  
            flake8 --select=F --ignore= --ignore=F403,F405 --per-file-ignores=**__init__.py:F401 --statistics

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,6 @@ jobs:
         uses: rbialon/flake8-annotations@v1
       - name: flake8 for syntax
         run: |
-           pip install importlib-metadata==4.13.0
+           python -m pip install importlib-metadata==4.13.0
            python -m pip install flake8==3.8.4  
            flake8 --select=F --ignore= --ignore=F403,F405 --per-file-ignores=**__init__.py:F401 --statistics

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,5 +18,6 @@ jobs:
         uses: rbialon/flake8-annotations@v1
       - name: flake8 for syntax
         run: |
+           pip install importlib-metadata==4.13.0
            python -m pip install flake8==3.8.4  
            flake8 --select=F --ignore= --ignore=F403,F405 --per-file-ignores=**__init__.py:F401 --statistics


### PR DESCRIPTION
Some lib metadata breaks everything. flake8 version was too old. Maybe we should stop fixing it.