### PR TITLE
Updated README to reflect that the pypi package has been renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ python -m pip install git+https://github.com/i-pi/i-pi.git
 
 Last Release::
 ```bash
-pip install -U i-PI
+pip install -U ipi
 ```
 
 Test with Pytest::

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ipi
-version = 2.6.0
+version = 2.6.2
 description = A Python interface for ab initio path integral molecular dynamics simulations
 long_description = file: README.md
 long_description_content_type = text/x-rst


### PR DESCRIPTION
OK so this is a mini-PR to discuss the renaming of the pypi package. I have also already created a workflow that automatically publishes a new release on pypi and gh when we merge a PR that contains a tag, so after we agree this can be merged let's tag this 2.6.2. 