### PR TITLE
Removed 'default_hypers_path' parameter from PETCalc call 

### DIFF
--- a/drivers/py/pes/pet.py
+++ b/drivers/py/pes/pet.py
@@ -55,7 +55,6 @@ Example: python driver.py -m pet -u -o model.json,template.xyz
         self.template_ase.arrays["forces"] = np.zeros_like(self.template_ase.positions)
         self.pet_calc = PETCalc(
             self.model_path,
-            default_hypers_path=self.model_path + "/default_hypers.yaml",
         )
 
     def __call__(self, cell, pos):


### PR DESCRIPTION
Talked to Sergey, the keyword is no longer needed for newest PET version (29.2.2024). I removed the keyword from the pet.py driver for i-pi