### PR TITLE
Ensure that sockets_prefix is passed to run_driver

### DIFF
--- a/drivers/py/driver.py
+++ b/drivers/py/driver.py
@@ -240,4 +240,5 @@ if __name__ == "__main__":
         port=args.port,
         driver=d_f,
         f_verbose=args.verbose,
+        sockets_prefix=args.sockets_prefix,
     )


### PR DESCRIPTION
This makes sure that the command line argument `-S` actually works as intended when passed to the python driver.