### PR TITLE
Fix aspects of interface between i-Pi and PLUMED that are not working

### DIFF
--- a/ipi/engine/forcefields.py
+++ b/ipi/engine/forcefields.py
@@ -705,13 +705,15 @@ class FFPlumed(FFEval):
         self.plumed.cmd("setMDEngine", "i-pi")
         self.plumed.cmd("setPlumedDat", self.plumeddat)
         self.plumed.cmd("setNatoms", self.natoms)
+        timeunit = 2.4188843e-05
+        self.plumed.cmd("setTimestep", 1/timeunit)
         self.plumed.cmd(
             "setMDEnergyUnits", 2625.4996
         )  # Pass a pointer to the conversion factor between the energy unit used in your code and kJ mol-1
         self.plumed.cmd(
             "setMDLengthUnits", 0.052917721
         )  # Pass a pointer to the conversion factor between the length unit used in your code and nm
-        self.plumed.cmd("setMDTimeUnits", 2.4188843e-05)
+        self.plumed.cmd("setMDTimeUnits", timeunit)
         self.plumedrestart = False
         if self.plumedstep > 0:
             # we are restarting, signal that PLUMED should continue

--- a/ipi/engine/forcefields.py
+++ b/ipi/engine/forcefields.py
@@ -705,7 +705,11 @@ class FFPlumed(FFEval):
         self.plumed.cmd("setMDEngine", "i-pi")
         self.plumed.cmd("setPlumedDat", self.plumeddat)
         self.plumed.cmd("setNatoms", self.natoms)
-        timeunit = 2.4188843e-05
+        timeunit = 2.4188843e-05  # atomic time to ps
+        self.plumed.cmd("setMDTimeUnits", timeunit)
+        # given we don't necessarily call plumed once per step, so time does not make
+        # sense, we set the time step so that time in plumed is a counter of the number of times
+        # called
         self.plumed.cmd("setTimestep", 1 / timeunit)
         self.plumed.cmd(
             "setMDEnergyUnits", 2625.4996
@@ -713,7 +717,6 @@ class FFPlumed(FFEval):
         self.plumed.cmd(
             "setMDLengthUnits", 0.052917721
         )  # Pass a pointer to the conversion factor between the length unit used in your code and nm
-        self.plumed.cmd("setMDTimeUnits", timeunit)
         self.plumedrestart = False
         if self.plumedstep > 0:
             # we are restarting, signal that PLUMED should continue

--- a/ipi/engine/forcefields.py
+++ b/ipi/engine/forcefields.py
@@ -706,7 +706,7 @@ class FFPlumed(FFEval):
         self.plumed.cmd("setPlumedDat", self.plumeddat)
         self.plumed.cmd("setNatoms", self.natoms)
         timeunit = 2.4188843e-05
-        self.plumed.cmd("setTimestep", 1/timeunit)
+        self.plumed.cmd("setTimestep", 1 / timeunit)
         self.plumed.cmd(
             "setMDEnergyUnits", 2625.4996
         )  # Pass a pointer to the conversion factor between the energy unit used in your code and kJ mol-1

--- a/ipi/engine/forcefields.py
+++ b/ipi/engine/forcefields.py
@@ -705,7 +705,6 @@ class FFPlumed(FFEval):
         self.plumed.cmd("setMDEngine", "i-pi")
         self.plumed.cmd("setPlumedDat", self.plumeddat)
         self.plumed.cmd("setNatoms", self.natoms)
-        self.plumed.cmd("setTimestep", 1.0)
         self.plumed.cmd(
             "setMDEnergyUnits", 2625.4996
         )  # Pass a pointer to the conversion factor between the energy unit used in your code and kJ mol-1
@@ -761,7 +760,7 @@ class FFPlumed(FFEval):
         self.plumed.cmd("setMasses", self.masses)
 
         # these instead are set properly. units conversion is done on the PLUMED side
-        self.plumed.cmd("setBox", r["cell"][0].T)
+        self.plumed.cmd("setBox", r["cell"][0].T.copy())
         pos = r["pos"].reshape(-1, 3)
 
         if self.system_force is not None:
@@ -807,7 +806,7 @@ class FFPlumed(FFEval):
         self.plumed.cmd("setMasses", self.masses)
         rpos = pos.reshape((-1, 3))
         self.plumed.cmd("setPositions", rpos)
-        self.plumed.cmd("setBox", cell.T)
+        self.plumed.cmd("setBox", cell.T.copy())
         if self.system_force is not None:
             f[:] = dstrip(self.system_force.f).reshape((-1, 3))
             vir[:] = -dstrip(self.system_force.vir)


### PR DESCRIPTION
There are two problems with the interface between i-Pi and PLUMED at the moment:

(1) The timestep is set incorrectly.  It is actually not possible to set the timestep correctly.  I have thus deleted the command to set the PLUMED timestep here. 

(2) The cell appears to be passed incorrect.  If you pass a deep copy of the NumPy array containing the cell as I do here I think the problem is fixed.

If you output a COLVAR file with PLUMED with this commit the output will look like this:

```
#! FIELDS time CV
0.00000  1.0
0.00000  2.0
0.00000  3.0
````

In other words, the CV column will be reported correctly but all the times will be zero as the timestep is not passed from the MD code.