### PR TITLE
Add rudimentary parsing of literals to PET driver

### DIFF
--- a/drivers/py/pes/pet.py
+++ b/drivers/py/pes/pet.py
@@ -54,6 +54,15 @@ Example: python driver.py -m pet -u -o "path/to/results/name,template.xyz,device
             if len(args) > 2:
                 for arg in args[2:]:
                     key, value = arg.split("=")
+                    lookup = {
+                        "None": None,
+                        "False": False,
+                        "True": True,
+                    }
+
+                    if value in lookup:
+                        value = lookup[value]
+
                     kwargs[key] = value
 
         else:


### PR DESCRIPTION
This is needed to pass non-strings such as `None`, `True`, or `False` into the `SingleStructCalculator`.

I've drawn the line at floats and ints, because it is not so easy to programmatically distinguish them, and it's not always clear what the intended type is supposed to be.