### PR TITLE
Fixed buggy env.sh

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,4 +1,21 @@
-ENV_BASE_DIR=$(cd "$(dirname "$(readlink -f "$script_path")")" && pwd)
+#!/bin/bash
+# sets environment variables for i-PI
+
+if [ -n "$BASH_SOURCE" ]; then
+    # Bash or zsh (if BASH_SOURCE is defined)
+    script="$BASH_SOURCE[0]"
+elif [ -n "$ZSH_VERSION" ]; then
+    # Zsh
+    script="${(%):-%x}"
+else
+    # Dash or POSIX sh
+    script="$0"
+fi
+
+ENV_BASE_DIR=$(cd "$(dirname "$(readlink -f "$script")")" && pwd)
+
+echo "Setting up i-PI paths to base folder $ENV_BASE_DIR"
+
 export PATH=$ENV_BASE_DIR/bin:$PATH
 export PYTHONPATH=$ENV_BASE_DIR:$PYTHONPATH
 export IPI_ROOT=$ENV_BASE_DIR


### PR DESCRIPTION
env.sh was broken, we didn't notice because we all have a proper pip install to fall back to. 
This should work on bash, dash and zsh