### PR TITLE
Clean up the kinetic temperature calculator

### DIFF
--- a/ipi/engine/properties.py
+++ b/ipi/engine/properties.py
@@ -1073,43 +1073,46 @@ class Properties:
               for. If not, then the simulation temperature.
         """
 
-        if self.ensemble.temp > 0 and self.motion.fixcom:
-            # Adds a fake momentum to the centre of mass. This is the easiest way
-            # of getting meaningful temperatures for subsets of the system when there
-            # are fixed components
-            M = np.sum(self.beads.m)
-            pcm = np.tile(
-                np.sqrt(M * Constants.kb * self.ensemble.temp * self.beads.nbeads), 3
-            )
-            vcm = np.tile(pcm / M, self.beads.natoms)
-
-            # we have to change p in place because the kinetic energy
-            # can depend on nm masses
-            self.beads.p += self.beads.m3 * vcm
-
-        if self.ensemble.temp > 0 and len(self.motion.fixatoms) > 0:
-            for i in self.motion.fixatoms:
-                pi = np.tile(
-                    np.sqrt(
-                        self.beads.m[i]
-                        * Constants.kb
-                        * self.ensemble.temp
-                        * self.beads.nbeads
-                    ),
+        if self.ensemble.temp > 0:
+            if self.motion.fixcom:
+                # Adds a fake momentum to the centre of mass. This is the easiest way
+                # of getting meaningful temperatures for subsets of the system when there
+                # are fixed components
+                M = np.sum(self.beads.m)
+                pcm = np.tile(
+                    np.sqrt(M * Constants.kb * self.ensemble.temp * self.beads.nbeads),
                     3,
                 )
-                self.beads.p[:, 3 * i : 3 * i + 3] = pi
+                vcm = np.tile(pcm / M, self.beads.natoms)
+
+                # we have to change p in place because the kinetic energy
+                # can depend on nm masses
+                self.beads.p += self.beads.m3 * vcm
+
+            if len(self.motion.fixatoms) > 0:
+                for i in self.motion.fixatoms:
+                    pi = np.tile(
+                        np.sqrt(
+                            self.beads.m[i]
+                            * Constants.kb
+                            * self.ensemble.temp
+                            * self.beads.nbeads
+                        ),
+                        3,
+                    )
+                    self.beads.p[:, 3 * i : 3 * i + 3] = pi
 
         kemd, ncount = self.get_kinmd(atom, bead, nm, return_count=True)
 
-        if self.motion.fixcom:
-            # Removes the fake momentum from the centre of mass.
-            self.beads.p -= self.beads.m3 * vcm
+        if self.ensemble.temp > 0:
+            if self.motion.fixcom:
+                # Removes the fake momentum from the centre of mass.
+                self.beads.p -= self.beads.m3 * vcm
 
-        if len(self.motion.fixatoms) > 0:
-            # re-fixes the fix atoms
-            for i in self.motion.fixatoms:
-                self.beads.p[:, 3 * i : 3 * i + 3] = 0.0
+            if len(self.motion.fixatoms) > 0:
+                # re-fixes the fix atoms
+                for i in self.motion.fixatoms:
+                    self.beads.p[:, 3 * i : 3 * i + 3] = 0.0
 
         return 2.0 * kemd / (Constants.kb * 3.0 * float(ncount) * self.beads.nbeads)
 

--- a/ipi/engine/properties.py
+++ b/ipi/engine/properties.py
@@ -1065,7 +1065,7 @@ class Properties:
         to the temperature. Rather than using a scaling factor based on the number of degrees
         of freedom, we add fake momenta to all the fixed components, so that a meaningful
         result will be obtained for each subset of coordinates regardless of the constraints
-        imposed on the system. Obviously printing the kinetic temperature only makes sense
+        imposed on the system. Computing the kinetic temperature only makes sense
         if you're running a constant-temperature ensemble.
 
         Args:

--- a/ipi/engine/properties.py
+++ b/ipi/engine/properties.py
@@ -1091,7 +1091,7 @@ class Properties:
 
             if len(self.motion.fixatoms) > 0:
                 for i in self.motion.fixatoms:
-                    pi = self.beads.sm[i] * tempfactor
+                    pi = self.beads.sm3[0, 3 * i] * tempfactor
                     dp[:, 3 * i : 3 * i + 3] = pi
 
             # we have to change p in place because the kinetic energy


### PR DESCRIPTION
Fixes errors when one (for whatever reason) prints temperature out of an NVE calculation