### PR TITLE
update documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,10 +30,10 @@ part of linting.
 In most systems, both packages can be easily installed using `pip`.
 BEFORE proceeding to a pull request, the minimal requirement is that you run
 
-::
-
-  $ make lint
-  $ make pretty
+```
+$ make lint
+$ make pretty
+```
 
 This will ensure the formatting and linting requirement are applied in the whole
 directory tree. Please resolve any warnings or errors that may appear. Your
@@ -42,6 +42,6 @@ commit will not pass the CI tests otherwise.
 For a more flexible setup, we also provide the script `i-pi-style`, for
 which instructions can be obtained by typing
 
-::
-
-  $ i-pi-style -h
+```
+$ i-pi-style -h
+```

--- a/drivers/README.md
+++ b/drivers/README.md
@@ -21,7 +21,7 @@ py
 --
 
 A Python version of the driver. Some simple potentials, and interfaces
-with codes that have a Python API can be found in the `forcefields/` 
+with codes that have a Python API can be found in the `pes/` 
 folder. 
 
 


### PR DESCRIPTION
These are a few points that I noticed in the documentation:
- rename readme to show markdown preview
- update code in the contributing guide to markdown
- change forcefields/ to pes/ in drivers readme