### PR TITLE
Better dev interface to force.copy (now renamed force.clone)

### DIFF
--- a/examples/features/geometry_optimization/BFGS_pswater/input.xml
+++ b/examples/features/geometry_optimization/BFGS_pswater/input.xml
@@ -1,4 +1,4 @@
-<simulation mode="static" verbosity="high">
+<simulation mode="static" verbosity="medium">
    <output prefix='simulation'>
     <properties stride='1' filename='out'>  [ step, potential{electronvolt}] </properties>
     <trajectory stride="1" filename="pos_c" format="xyz"> x_centroid </trajectory>

--- a/examples/features/geometry_optimization/BFGS_pswater/input.xml
+++ b/examples/features/geometry_optimization/BFGS_pswater/input.xml
@@ -1,4 +1,4 @@
-<simulation mode="static" verbosity="medium">
+<simulation mode="static" verbosity="high">
    <output prefix='simulation'>
     <properties stride='1' filename='out'>  [ step, potential{electronvolt}] </properties>
     <trajectory stride="1" filename="pos_c" format="xyz"> x_centroid </trajectory>

--- a/ipi/engine/beads.py
+++ b/ipi/engine/beads.py
@@ -166,7 +166,7 @@ class Beads:
             dependencies=[b._kstress for b in self._blist],
         )
 
-    def copy(self, nbeads=-1):
+    def clone(self, nbeads=-1):
         """Creates a new beads object with newP <= P beads from the original.
 
         Returns:
@@ -174,7 +174,7 @@ class Beads:
         """
 
         if nbeads > self.nbeads:
-            raise ValueError("Cannot copy to an object with larger number of beads")
+            raise ValueError("Cannot clone to an object with larger number of beads")
         elif nbeads == -1:
             nbeads = self.nbeads
 

--- a/ipi/engine/cell.py
+++ b/ipi/engine/cell.py
@@ -51,7 +51,7 @@ class Cell:
         )
         self._V = depend_value(name="V", func=self.get_volume, dependencies=[self._h])
 
-    def copy(self):
+    def clone(self):
         return Cell(dstrip(self.h).copy())
 
     def get_ih(self):

--- a/ipi/engine/forces.py
+++ b/ipi/engine/forces.py
@@ -1122,7 +1122,7 @@ class Forces:
         force.load_state(old_state)
         """
 
-        self.load_state(refforce.dump_state)
+        self.load_state(refforce.dump_state())
 
     def transfer_forces_manual(
         self, new_q, new_v, new_forces, new_x=None, vir=np.zeros((3, 3))

--- a/ipi/engine/forces.py
+++ b/ipi/engine/forces.py
@@ -1058,7 +1058,7 @@ class Forces:
             force_data.append(
                 (
                     # will also need bead positions, see _load_state
-                    deepcopy(mself.beads._q._value),
+                    deepcopy(dstrip(mself.beads.q)),
                     bead_forces,
                 )
             )

--- a/ipi/engine/forces.py
+++ b/ipi/engine/forces.py
@@ -1044,7 +1044,9 @@ class Forces:
 
     def dump_state(self):
         """
-        Stores a (deep) copy of the internal state of a force object
+        Stores a (deep) copy of the internal state of a force object.
+        See `transfer_forces` for an explanation of the usage and
+        logic.
         """
 
         force_data = []
@@ -1067,7 +1069,7 @@ class Forces:
     def load_state(self, state):
         """
         Loads a previously-saved state of a force object. See
-        `transfere_forces` for an explanation of the usage and
+        `transfer_forces` for an explanation of the usage and
         logic.
         """
 
@@ -1135,7 +1137,7 @@ class Forces:
           - new_f list of length equal to number of force type, containing the beads forces
           - new_x list of length equal to number of force type, containing the beads extras
         """
-        msg = "Unconsistent dimensions inside transfer_forces_manual"
+        msg = "Inconsistent dimensions inside transfer_forces_manual"
         assert len(self.mforces) == len(new_q), msg
         assert len(self.mforces) == len(new_v), msg
         assert len(self.mforces) == len(new_forces), msg

--- a/ipi/engine/forces.py
+++ b/ipi/engine/forces.py
@@ -24,6 +24,7 @@ from ipi.utils.messages import verbosity, warning, info
 from ipi.utils.depend import *
 from ipi.utils.nmtransform import nm_rescale
 from ipi.engine.beads import Beads
+from ipi.engine.cell import Cell
 
 
 __all__ = ["Forces", "ForceComponent"]

--- a/ipi/engine/motion/al6xxx_kmc.py
+++ b/ipi/engine/motion/al6xxx_kmc.py
@@ -290,7 +290,7 @@ class AlKMC(Motion):
         self.dens = [None] * self.neval
         self.dbias = [None] * self.neval
         for i in range(self.neval):
-            self.dbeads[i] = beads.copy()
+            self.dbeads[i] = beads.clone()
             self.dforces[i] = bforce.copy(self.dbeads[i], self.dcell)
             self.dnm[i] = nm.copy()
             self.dens[i] = ens.copy()

--- a/ipi/engine/motion/atomswap.py
+++ b/ipi/engine/motion/atomswap.py
@@ -64,9 +64,9 @@ class AtomSwap(Motion):
 
         super(AtomSwap, self).bind(ens, beads, cell, bforce, nm, prng, omaker)
         self.ensemble.add_econs(self._ealc)
-        self.dbeads = self.beads.copy()
-        self.dcell = self.cell.copy()
-        self.dforces = self.forces.copy(self.dbeads, self.dcell)
+        self.dbeads = self.beads.clone()
+        self.dcell = self.cell.clone()
+        self.dforces = self.forces.clone(self.dbeads, self.dcell)
 
     def AXlist(self, atomtype):
         """This compile a list of atoms ready for exchanges."""

--- a/ipi/engine/motion/geop.py
+++ b/ipi/engine/motion/geop.py
@@ -195,9 +195,9 @@ class LineMapper(object):
         self.fcount = 0
 
     def bind(self, dumop):
-        self.dbeads = dumop.beads.copy()
-        self.dcell = dumop.cell.copy()
-        self.dforces = dumop.forces.copy(self.dbeads, self.dcell)
+        self.dbeads = dumop.beads.clone()
+        self.dcell = dumop.cell.clone()
+        self.dforces = dumop.forces.clone(self.dbeads, self.dcell)
 
         self.fixatoms_mask = np.ones(
             3 * dumop.beads.natoms, dtype=bool
@@ -249,9 +249,9 @@ class GradientMapper(object):
         pass
 
     def bind(self, dumop):
-        self.dbeads = dumop.beads.copy()
-        self.dcell = dumop.cell.copy()
-        self.dforces = dumop.forces.copy(self.dbeads, self.dcell)
+        self.dbeads = dumop.beads.clone()
+        self.dcell = dumop.cell.clone()
+        self.dforces = dumop.forces.clone(self.dbeads, self.dcell)
 
         self.fixatoms_mask = np.ones(
             3 * dumop.beads.natoms, dtype=bool

--- a/ipi/engine/motion/instanton.py
+++ b/ipi/engine/motion/instanton.py
@@ -268,9 +268,9 @@ class PesMapper(object):
         pass
 
     def bind(self, mapper):
-        self.dbeads = mapper.beads.copy()
-        self.dcell = mapper.cell.copy()
-        self.dforces = mapper.forces.copy(self.dbeads, self.dcell)
+        self.dbeads = mapper.beads.clone()
+        self.dcell = mapper.cell.clone()
+        self.dforces = mapper.forces.clone(self.dbeads, self.dcell)
 
         # self.nm = mapper.nm
         # self.rp_factor = mapper.rp_factor
@@ -355,8 +355,8 @@ class PesMapper(object):
         reduced_b.m[:] = self.dbeads.m
         reduced_b.names[:] = self.dbeads.names
 
-        reduced_cell = self.dcell.copy()
-        reduced_forces = self.dforces.copy(reduced_b, reduced_cell)
+        reduced_cell = self.dcell.clone()
+        reduced_forces = self.dforces.clone(reduced_b, reduced_cell)
 
         # Evaluate energy and forces (and maybe friction)
         rpots = reduced_forces.pots  # reduced energy
@@ -690,7 +690,7 @@ class SpringMapper(object):
         self.temp = mapper.temp
         self.fix = mapper.fix
         self.coef = mapper.coef
-        self.dbeads = mapper.beads.copy()
+        self.dbeads = mapper.beads.clone()
         # self.nm = mapper.nm
         # self.rp_factor = mapper.rp_factor
         if self.dbeads.nbeads > 1:

--- a/ipi/engine/motion/neb.py
+++ b/ipi/engine/motion/neb.py
@@ -91,6 +91,9 @@ class NEBGradientMapper(object):
             self.allpots = dstrip(self.dforces.pots).copy()
             # We want to be greedy about force calls,
             # so we transfer from full beads to the reduced ones.
+            # MR note, 2024: The call below is overly convoluted and
+            # likely unnecessary. It should be possible to dump values
+            # now, or use usual transfer_forces. Needs deep revision.
             tmp_f = self.dforces.f.copy()[1:-1]
             tmp_v = self.allpots.copy()[1:-1]
             self.rforces.transfer_forces_manual(

--- a/ipi/engine/motion/neb.py
+++ b/ipi/engine/motion/neb.py
@@ -51,9 +51,9 @@ class NEBGradientMapper(object):
         # In principle, there is no need in dforces within the Mapper,
         # BUT dbeads are needed to calculate tangents for the endpoints,
         # and dforces are needed outside the Mapper to construct the "main" forces.
-        self.dbeads = ens.beads.copy()
-        self.dcell = ens.cell.copy()
-        self.dforces = ens.forces.copy(self.dbeads, self.dcell)
+        self.dbeads = ens.beads.clone()
+        self.dcell = ens.cell.clone()
+        self.dforces = ens.forces.clone(self.dbeads, self.dcell)
         self.fixatoms = ens.fixatoms.copy()
 
         # Mask to exclude fixed atoms from 3N-arrays
@@ -66,7 +66,7 @@ class NEBGradientMapper(object):
         # Create reduced bead and force object
         self.rbeads = Beads(ens.beads.natoms, ens.beads.nbeads - 2)
         self.rbeads.q[:] = ens.beads.q[1:-1]
-        self.rforces = ens.forces.copy(self.rbeads, self.dcell)
+        self.rforces = ens.forces.clone(self.rbeads, self.dcell)
 
     def __call__(self, x):
         """Returns the potential for all beads and the gradient."""
@@ -245,12 +245,12 @@ class NEBClimbGrMapper(object):
 
         # Reduced Beads object is needed to calculate only required beads.
         self.rbeads = Beads(ens.beads.natoms, 1)
-        self.rcell = ens.cell.copy()
+        self.rcell = ens.cell.clone()
         # Coords of the bead before and after the climbing one.
         self.q_prev = np.zeros(3 * (ens.beads.natoms - len(ens.fixatoms)))
         self.q_next = np.zeros(3 * (ens.beads.natoms - len(ens.fixatoms)))
         # Make reduced forces dependent on reduced beads
-        self.rforces = ens.forces.copy(self.rbeads, self.rcell)
+        self.rforces = ens.forces.clone(self.rbeads, self.rcell)
 
     def __call__(self, x):
         """Returns climbing force for a climbing image."""

--- a/ipi/engine/motion/phonons.py
+++ b/ipi/engine/motion/phonons.py
@@ -98,9 +98,9 @@ class DynMatrixMover(Motion):
         self.m = dstrip(self.beads.m)
         self.phcalc.bind(self)
 
-        self.dbeads = self.beads.copy()
-        self.dcell = self.cell.copy()
-        self.dforces = self.forces.copy(self.dbeads, self.dcell)
+        self.dbeads = self.beads.clone()
+        self.dcell = self.cell.clone()
+        self.dforces = self.forces.clone(self.dbeads, self.dcell)
 
     def step(self, step=None):
         """Executes one step of phonon computation."""

--- a/ipi/engine/motion/planetary.py
+++ b/ipi/engine/motion/planetary.py
@@ -115,8 +115,8 @@ class Planetary(Motion):
         self.basenm = nm
 
         # copies of all of the helper classes that are needed to bind the ccdyn object
-        self.dbeads = beads.copy(nbeads=self.nbeads)
-        self.dcell = cell.copy()
+        self.dbeads = beads.clone(nbeads=self.nbeads)
+        self.dcell = cell.clone()
         self.dforces = bforce.copy(self.dbeads, self.dcell)
 
         # options for NM propagation - hardcoded frequencies unless using a GLE thermo

--- a/ipi/engine/motion/scphonons.py
+++ b/ipi/engine/motion/scphonons.py
@@ -132,9 +132,9 @@ class SCPhononsMover(Motion):
 
         # Creates duplicate classes to simplify computation of forces.
         self.dof = 3 * self.beads.natoms
-        self.dbeads = self.beads.copy(nbeads=self.nparallel)
-        self.dcell = self.cell.copy()
-        self.dforces = self.forces.copy(self.dbeads, self.dcell)
+        self.dbeads = self.beads.clone(nbeads=self.nparallel)
+        self.dcell = self.cell.clone()
+        self.dforces = self.forces.clone(self.dbeads, self.dcell)
 
         # Sets temperature.
         self.temp = self.ensemble.temp

--- a/ipi/engine/motion/stringmep.py
+++ b/ipi/engine/motion/stringmep.py
@@ -61,9 +61,9 @@ class StringGradientMapper(object):
         # In principle, there is no need in dforces within the Mapper,
         # BUT dbeads are needed to calculate tangents for the endpoints,
         # and dforces are needed outside the Mapper to construct the "main" forces.
-        self.dbeads = ens.beads.copy()
-        self.dcell = ens.cell.copy()
-        self.dforces = ens.forces.copy(self.dbeads, self.dcell)
+        self.dbeads = ens.beads.clone()
+        self.dcell = ens.cell.clone()
+        self.dforces = ens.forces.clone(self.dbeads, self.dcell)
         self.fixatoms = ens.fixatoms.copy()
 
         # Mask to exclude fixed atoms from 3N-arrays
@@ -76,7 +76,7 @@ class StringGradientMapper(object):
         # Create reduced bead and force object
         self.rbeads = Beads(ens.beads.natoms, ens.beads.nbeads - 2)
         self.rbeads.q[:] = ens.beads.q[1:-1]
-        self.rforces = ens.forces.copy(self.rbeads, self.dcell)
+        self.rforces = ens.forces.clone(self.rbeads, self.dcell)
 
     def __call__(self, x):
         """Returns the potential for all beads and the gradient."""
@@ -130,9 +130,9 @@ class GradientMapper(object):
         # In principle, there is no need in dforces within the Mapper,
         # BUT dbeads are needed to calculate tangents for the endpoints,
         # and dforces are needed outside the Mapper to construct the "main" forces.
-        self.dbeads = ens.beads.copy()
-        self.dcell = ens.cell.copy()
-        self.dforces = ens.forces.copy(self.dbeads, self.dcell)
+        self.dbeads = ens.beads.clone()
+        self.dcell = ens.cell.clone()
+        self.dforces = ens.forces.clone(self.dbeads, self.dcell)
         self.fixatoms = ens.fixatoms.copy()
 
         # Mask to exclude fixed atoms from 3N-arrays
@@ -145,7 +145,7 @@ class GradientMapper(object):
         # Create reduced bead and force object
         self.rbeads = Beads(ens.beads.natoms, ens.beads.nbeads - 2)
         self.rbeads.q[:] = ens.beads.q[1:-1]
-        self.rforces = ens.forces.copy(self.rbeads, self.dcell)
+        self.rforces = ens.forces.clone(self.rbeads, self.dcell)
 
     def __call__(self, x):
         """Returns the potential for all beads and the gradient."""
@@ -199,12 +199,12 @@ class StringClimbGrMapper(object):
 
         # Reduced Beads object is needed to calculate only required beads.
         self.rbeads = Beads(ens.beads.natoms, 1)
-        self.rcell = ens.cell.copy()
+        self.rcell = ens.cell.clone()
         # Coords of the bead before and after the climbing one.
         self.q_prev = np.zeros(3 * (ens.beads.natoms - len(ens.fixatoms)))
         self.q_next = np.zeros(3 * (ens.beads.natoms - len(ens.fixatoms)))
         # Make reduced forces dependent on reduced beads
-        self.rforces = ens.forces.copy(self.rbeads, self.rcell)
+        self.rforces = ens.forces.clone(self.rbeads, self.rcell)
 
     def __call__(self, x):
         """Returns climbing force for a climbing image."""

--- a/ipi/engine/motion/vscf.py
+++ b/ipi/engine/motion/vscf.py
@@ -145,9 +145,9 @@ class NormalModeMover(Motion):
         self.m = dstrip(self.beads.m)
         self.calc.bind(self)
 
-        self.dbeads = self.beads.copy(nbeads=self.nparallel)
-        self.dcell = self.cell.copy()
-        self.dforces = self.forces.copy(self.dbeads, self.dcell)
+        self.dbeads = self.beads.clone(nbeads=self.nparallel)
+        self.dcell = self.cell.clone()
+        self.dforces = self.forces.clone(self.dbeads, self.dcell)
 
     def step(self, step=None):
         """Executes one step of phonon computation."""

--- a/ipi/engine/properties.py
+++ b/ipi/engine/properties.py
@@ -957,9 +957,9 @@ class Properties:
         # dummy beads and forcefield objects so that we can use scaled and
         # displaced path estimators without changing the simulation bead
         # coordinates
-        self.dbeads = system.beads.copy()
-        self.dcell = system.cell.copy()
-        self.dforces = system.forces.copy(self.dbeads, self.dcell)
+        self.dbeads = system.beads.clone()
+        self.dcell = system.cell.clone()
+        self.dforces = system.forces.clone(self.dbeads, self.dcell)
         self.fqref = None
         self._threadlock = (
             system._propertylock
@@ -2989,15 +2989,15 @@ class Trajectories:
         # dummy beads and forcefield objects so that we can use scaled and
         # displaced path estimators without changing the simulation bead
         # coordinates
-        self.dbeads = system.beads.copy()
-        self.dcell = system.cell.copy()
-        self.dforces = self.system.forces.copy(self.dbeads, self.dcell)
+        self.dbeads = system.beads.clone()
+        self.dcell = system.cell.clone()
+        self.dforces = self.system.forces.clone(self.dbeads, self.dcell)
         self._threadlock = system._propertylock
 
         if system.beads.nbeads >= 2:
-            self.scdbeads = system.beads.copy(system.beads.nbeads // 2)
-            self.scdcell = system.cell.copy()
-            self.scdforces = self.system.forces.copy(self.scdbeads, self.scdcell)
+            self.scdbeads = system.beads.clone(system.beads.nbeads // 2)
+            self.scdcell = system.cell.clone()
+            self.scdforces = self.system.forces.clone(self.scdbeads, self.scdcell)
 
     def get_akcv(self):
         """Calculates the contribution to the kinetic energy due to each degree

--- a/ipi/utils/instools.py
+++ b/ipi/utils/instools.py
@@ -328,9 +328,9 @@ class Fix(object):
         self.mask2 = np.arange(3 * self.natoms * self.nbeads)[mask2]
 
         self.fixbeads = Beads(beads.natoms - len(fixatoms), beads.nbeads)
-        self.fixbeads.q[:] = self.get_active_vector(beads.copy().q, 1)
-        self.fixbeads.m[:] = self.get_active_vector(beads.copy().m, 0)
-        self.fixbeads.names[:] = self.get_active_vector(beads.copy().names, 0)
+        self.fixbeads.q[:] = self.get_active_vector(beads.clone().q, 1)
+        self.fixbeads.m[:] = self.get_active_vector(beads.clone().m, 0)
+        self.fixbeads.names[:] = self.get_active_vector(beads.clone().names, 0)
 
         mask3a = np.ones(9 * self.natoms, dtype=bool)
         for i in range(9):

--- a/tools/py/Instanton_interpolation.py
+++ b/tools/py/Instanton_interpolation.py
@@ -128,7 +128,7 @@ if input_geo != "None" or chk != "None":
             print("We can't find {}".format(chk))
             sys.exit()
         cell = simulation.syslist[0].cell
-        beads = simulation.syslist[0].motion.beads.copy()
+        beads = simulation.syslist[0].motion.beads.clone()
         natoms = simulation.syslist[0].motion.beads.natoms
         nbeads = beads.nbeads
         q = beads.q

--- a/tools/py/Instanton_postproc.py
+++ b/tools/py/Instanton_postproc.py
@@ -263,7 +263,7 @@ simulation = Simulation.load_from_xml(
 )
 
 
-beads = simulation.syslist[0].motion.beads.copy()
+beads = simulation.syslist[0].motion.beads.clone()
 m = simulation.syslist[0].motion.beads.m.copy()
 nbeads = simulation.syslist[0].motion.beads.nbeads
 natoms = simulation.syslist[0].motion.beads.natoms

--- a/tools/py/neb_interpolate.py
+++ b/tools/py/neb_interpolate.py
@@ -358,7 +358,7 @@ if __name__ == "__main__":
             print("Error: cannot find {}.".format(input_chk))
             sys.exit()
         cell = simulation.syslist[0].cell
-        beads = simulation.syslist[0].motion.beads.copy()
+        beads = simulation.syslist[0].motion.beads.clone()
         natoms = simulation.syslist[0].motion.beads.natoms
         masses = simulation.syslist[0].motion.beads.m  # KF: not sure about this line
         nbeads_old = beads.nbeads


### PR DESCRIPTION
Forces.copy allowed to pass None for the target beads and cell object, but it's likely this was always broken.
To make life easier for devs, beads and cell are now mandatory, docstring is a bit clearer, and function is renamed to clone() to hint that it does more than a shallow (or deep) copy. 