### PR TITLE
Prevent new `xtb` module from crashing simulations

### DIFF
--- a/drivers/py/pes/xtb.py
+++ b/drivers/py/pes/xtb.py
@@ -14,9 +14,16 @@ from ipi.utils.units import unit_to_internal, unit_to_user
 try:
     import tblite.interface as tb
 except ImportError as e:
-    raise ModuleNotFoundError(
-        "Could not find tblite for xtb driver. Please install tblite-python with mamba"
-    ) from e
+    class TBLiteDriver:
+        def __init__(
+            self,
+            args="",
+            verbose=False,
+        ):
+            raise ModuleNotFoundError(
+                "Could not find tblite for xtb driver. Please install tblite-python with mamba"
+            )
+        
 
 __DRIVER_NAME__ = "xtb"
 __DRIVER_CLASS__ = "TBLiteDriver"

--- a/drivers/py/pes/xtb.py
+++ b/drivers/py/pes/xtb.py
@@ -13,17 +13,9 @@ from ipi.utils.units import unit_to_internal, unit_to_user
 
 try:
     import tblite.interface as tb
-except ImportError as e:
-    class TBLiteDriver:
-        def __init__(
-            self,
-            args="",
-            verbose=False,
-        ):
-            raise ModuleNotFoundError(
-                "Could not find tblite for xtb driver. Please install tblite-python with mamba"
-            )
-        
+except ImportError:
+    tb = None
+
 
 __DRIVER_NAME__ = "xtb"
 __DRIVER_CLASS__ = "TBLiteDriver"
@@ -38,6 +30,12 @@ class TBLiteDriver(object):
         verbose=False,
     ):
         """Initialized dummy drivers"""
+
+        if tb is None:
+            raise ModuleNotFoundError(
+                "Could not find tblite for xtb driver. Please install tblite-python with mamba"
+            )
+
         config = json.loads(args)
         try:
             self.method = config["method"]


### PR DESCRIPTION
If `tblite` is not installed, an import is attempted and this crashes i-PI due to the error raise. This should fix it