### PR TITLE
  Changing the default behaviour of the seed of the random number generator.

### DIFF
--- a/ipi/inputs/prng.py
+++ b/ipi/inputs/prng.py
@@ -53,7 +53,7 @@ if the arrays are very large.
                 "dtype": int,
                 #                "default": 123456,
                 "default": -1,
-                "help": "This is the seed number used to generate the initial state of the random number generator. Previously, the seed was fixed as 123456. Currently, the seed is random and given by the system time (down to ms). This is done in utils/prng.py.",
+                "help": "This specifies the seed number used to generate the initial state of the random number generator. Previously, the default seed was fixed as 123456. Currently, the default seed is random and given by the system time (down to ms). This is done in utils/prng.py.",
             },
         ),
         "state": (

--- a/ipi/inputs/prng.py
+++ b/ipi/inputs/prng.py
@@ -51,8 +51,9 @@ if the arrays are very large.
             InputValue,
             {
                 "dtype": int,
-                "default": 123456,
-                "help": "This is the seed number used to generate the initial state of the random number generator.",
+                #                "default": 123456,
+                "default": -1,
+                "help": "This is the seed number used to generate the initial state of the random number generator. Previously, the seed was fixed as 123456. Currently, the seed is random and given by the system time (down to ms). This is done in utils/prng.py.",
             },
         ),
         "state": (

--- a/ipi/utils/prng.py
+++ b/ipi/utils/prng.py
@@ -14,6 +14,9 @@ it had not been stopped.
 
 import numpy as np
 import concurrent.futures
+import time
+from ipi.utils.messages import verbosity, info
+import threading
 
 __all__ = ["Random"]
 
@@ -39,7 +42,7 @@ class Random(object):
             Gaussian random number returned.
     """
 
-    def __init__(self, seed=12345, state=None, n_threads=1):
+    def __init__(self, seed=-1, state=None, n_threads=1):
         """Initialises Random.
 
         Args:
@@ -49,7 +52,19 @@ class Random(object):
                     arrays to be filled are large!)
         """
 
+        # Here we make the seed random if it has not been specified in the input file
+        if seed == -1:
+            seed = int(time.time() * 1000)
+
         self.seed = seed
+
+        if threading.current_thread() == threading.main_thread():
+            info(
+                "@ RANDOM SEED: The seed used in this calculation was "
+                + str(self.seed),
+                verbosity.low,
+            )
+
         self.rng = [
             np.random.Generator(np.random.MT19937(s))
             for s in np.random.SeedSequence(seed).spawn(n_threads)

--- a/ipi_tests/regression_tests/tests/GEOP/BFGS-TRM/harmonic/input.xml
+++ b/ipi_tests/regression_tests/tests/GEOP/BFGS-TRM/harmonic/input.xml
@@ -5,7 +5,7 @@
     <trajectory stride="1" filename="frc_c" format="xyz"> f_centroid </trajectory>
    </output>
    <prng>
-      <seed> 12345 </seed>
+      <seed> 123456 </seed>
    </prng>
    <total_steps> 10 </total_steps>
    <ffsocket name="harm3d" mode="unix">

--- a/ipi_tests/regression_tests/tests/GEOP/BFGS-TRM/harmonic/input.xml
+++ b/ipi_tests/regression_tests/tests/GEOP/BFGS-TRM/harmonic/input.xml
@@ -4,6 +4,9 @@
     <trajectory stride="1" filename="pos_c" format="xyz"> x_centroid </trajectory>
     <trajectory stride="1" filename="frc_c" format="xyz"> f_centroid </trajectory>
    </output>
+   <prng>
+      <seed> 12345 </seed>
+   </prng>
    <total_steps> 10 </total_steps>
    <ffsocket name="harm3d" mode="unix">
        <address> localhost </address> 

--- a/ipi_tests/regression_tests/tests/GEOP/BFGS-TRM/pswater/input.xml
+++ b/ipi_tests/regression_tests/tests/GEOP/BFGS-TRM/pswater/input.xml
@@ -4,6 +4,9 @@
     <trajectory stride="1" filename="pos_c" format="xyz"> x_centroid </trajectory>
     <trajectory stride="1" filename="frc_c" format="xyz"> f_centroid </trajectory>
    </output>
+   <prng>
+      <seed> 12345 </seed>
+   </prng>
    <total_steps> 10 </total_steps>
    <ffsocket name="pswater" mode="unix">
        <address> localhost </address> 

--- a/ipi_tests/regression_tests/tests/GEOP/BFGS-TRM/pswater/input.xml
+++ b/ipi_tests/regression_tests/tests/GEOP/BFGS-TRM/pswater/input.xml
@@ -5,7 +5,7 @@
     <trajectory stride="1" filename="frc_c" format="xyz"> f_centroid </trajectory>
    </output>
    <prng>
-      <seed> 12345 </seed>
+      <seed> 123456 </seed>
    </prng>
    <total_steps> 10 </total_steps>
    <ffsocket name="pswater" mode="unix">

--- a/ipi_tests/regression_tests/tests/GEOP/BFGS/harmonic/input.xml
+++ b/ipi_tests/regression_tests/tests/GEOP/BFGS/harmonic/input.xml
@@ -5,7 +5,7 @@
     <trajectory stride="1" filename="frc_c" format="xyz"> f_centroid </trajectory>
    </output>
    <prng>
-      <seed> 12345 </seed>
+      <seed> 123456 </seed>
    </prng>
    <total_steps> 10 </total_steps>
    <ffsocket name="harm3d" mode="unix">

--- a/ipi_tests/regression_tests/tests/GEOP/BFGS/harmonic/input.xml
+++ b/ipi_tests/regression_tests/tests/GEOP/BFGS/harmonic/input.xml
@@ -4,6 +4,9 @@
     <trajectory stride="1" filename="pos_c" format="xyz"> x_centroid </trajectory>
     <trajectory stride="1" filename="frc_c" format="xyz"> f_centroid </trajectory>
    </output>
+   <prng>
+      <seed> 12345 </seed>
+   </prng>
    <total_steps> 10 </total_steps>
    <ffsocket name="harm3d" mode="unix">
        <address> localhost </address> 

--- a/ipi_tests/regression_tests/tests/GEOP/BFGS/pswater/input.xml
+++ b/ipi_tests/regression_tests/tests/GEOP/BFGS/pswater/input.xml
@@ -4,6 +4,9 @@
     <trajectory stride="1" filename="pos_c" format="xyz"> x_centroid </trajectory>
     <trajectory stride="1" filename="frc_c" format="xyz"> f_centroid </trajectory>
    </output>
+   <prng>
+      <seed> 12345 </seed>
+   </prng>
    <total_steps> 10 </total_steps>
    <ffsocket name="pswater" mode="unix">
        <address> localhost </address> 

--- a/ipi_tests/regression_tests/tests/GEOP/BFGS/pswater/input.xml
+++ b/ipi_tests/regression_tests/tests/GEOP/BFGS/pswater/input.xml
@@ -5,7 +5,7 @@
     <trajectory stride="1" filename="frc_c" format="xyz"> f_centroid </trajectory>
    </output>
    <prng>
-      <seed> 12345 </seed>
+      <seed> 123456 </seed>
    </prng>
    <total_steps> 10 </total_steps>
    <ffsocket name="pswater" mode="unix">

--- a/ipi_tests/regression_tests/tests/GEOP/CG/harmonic/input.xml
+++ b/ipi_tests/regression_tests/tests/GEOP/CG/harmonic/input.xml
@@ -5,7 +5,7 @@
     <trajectory stride="1" filename="frc_c" format="xyz"> f_centroid </trajectory>
    </output>
    <prng>
-      <seed> 12345 </seed>
+      <seed> 123456 </seed>
    </prng>
    <total_steps> 10 </total_steps>
    <ffsocket name="harm3d" mode="unix">

--- a/ipi_tests/regression_tests/tests/GEOP/CG/harmonic/input.xml
+++ b/ipi_tests/regression_tests/tests/GEOP/CG/harmonic/input.xml
@@ -4,6 +4,9 @@
     <trajectory stride="1" filename="pos_c" format="xyz"> x_centroid </trajectory>
     <trajectory stride="1" filename="frc_c" format="xyz"> f_centroid </trajectory>
    </output>
+   <prng>
+      <seed> 12345 </seed>
+   </prng>
    <total_steps> 10 </total_steps>
    <ffsocket name="harm3d" mode="unix">
        <address> localhost </address> 

--- a/ipi_tests/regression_tests/tests/GEOP/LBFGS/harmonic/input.xml
+++ b/ipi_tests/regression_tests/tests/GEOP/LBFGS/harmonic/input.xml
@@ -5,7 +5,7 @@
     <trajectory stride="1" filename="frc_c" format="xyz"> f_centroid </trajectory>
    </output>
    <prng>
-      <seed> 12345 </seed>
+      <seed> 123456 </seed>
    </prng>
    <total_steps> 10 </total_steps>
    <ffsocket name="harm3d" mode="unix">

--- a/ipi_tests/regression_tests/tests/GEOP/LBFGS/harmonic/input.xml
+++ b/ipi_tests/regression_tests/tests/GEOP/LBFGS/harmonic/input.xml
@@ -4,6 +4,9 @@
     <trajectory stride="1" filename="pos_c" format="xyz"> x_centroid </trajectory>
     <trajectory stride="1" filename="frc_c" format="xyz"> f_centroid </trajectory>
    </output>
+   <prng>
+      <seed> 12345 </seed>
+   </prng>
    <total_steps> 10 </total_steps>
    <ffsocket name="harm3d" mode="unix">
        <address> localhost </address> 

--- a/ipi_tests/regression_tests/tests/GEOP/LBFGS/pswater/input.xml
+++ b/ipi_tests/regression_tests/tests/GEOP/LBFGS/pswater/input.xml
@@ -4,6 +4,9 @@
     <trajectory stride="1" filename="pos_c" format="xyz"> x_centroid </trajectory>
     <trajectory stride="1" filename="frc_c" format="xyz"> f_centroid </trajectory>
    </output>
+   <prng>
+      <seed> 12345 </seed>
+   </prng>
    <total_steps> 10 </total_steps>
    <ffsocket name="pswater" mode="unix">
        <address> localhost </address> 

--- a/ipi_tests/regression_tests/tests/GEOP/LBFGS/pswater/input.xml
+++ b/ipi_tests/regression_tests/tests/GEOP/LBFGS/pswater/input.xml
@@ -5,7 +5,7 @@
     <trajectory stride="1" filename="frc_c" format="xyz"> f_centroid </trajectory>
    </output>
    <prng>
-      <seed> 12345 </seed>
+      <seed> 123456 </seed>
    </prng>
    <total_steps> 10 </total_steps>
    <ffsocket name="pswater" mode="unix">

--- a/ipi_tests/regression_tests/tests/INSTANTON/070K_D/input.xml
+++ b/ipi_tests/regression_tests/tests/INSTANTON/070K_D/input.xml
@@ -2,6 +2,9 @@
     <output prefix='simulation'>
         <properties stride='1' filename='out'>  [ step, potential{electronvolt}] </properties>
    </output>
+   <prng>
+      <seed> 12345 </seed>
+   </prng>
    <total_steps>1000       </total_steps>
    <ffsocket name="doublewell" mode="unix" >
        <address> localhost </address> 

--- a/ipi_tests/regression_tests/tests/INSTANTON/070K_D/input.xml
+++ b/ipi_tests/regression_tests/tests/INSTANTON/070K_D/input.xml
@@ -3,7 +3,7 @@
         <properties stride='1' filename='out'>  [ step, potential{electronvolt}] </properties>
    </output>
    <prng>
-      <seed> 12345 </seed>
+      <seed> 123456 </seed>
    </prng>
    <total_steps>1000       </total_steps>
    <ffsocket name="doublewell" mode="unix" >

--- a/ipi_tests/regression_tests/tests/INSTANTON/100K_implicit_friction/input.xml
+++ b/ipi_tests/regression_tests/tests/INSTANTON/100K_implicit_friction/input.xml
@@ -3,7 +3,7 @@
         <properties stride='1' filename='out'>  [ step, potential{electronvolt}] </properties>
    </output>
    <prng>
-      <seed> 12345 </seed>
+      <seed> 123456 </seed>
    </prng>
    <total_steps>35      </total_steps>
    <ffsocket name="doublewell_1D" mode="unix" >

--- a/ipi_tests/regression_tests/tests/INSTANTON/100K_implicit_friction/input.xml
+++ b/ipi_tests/regression_tests/tests/INSTANTON/100K_implicit_friction/input.xml
@@ -2,6 +2,9 @@
     <output prefix='simulation'>
         <properties stride='1' filename='out'>  [ step, potential{electronvolt}] </properties>
    </output>
+   <prng>
+      <seed> 12345 </seed>
+   </prng>
    <total_steps>35      </total_steps>
    <ffsocket name="doublewell_1D" mode="unix" >
        <address> localhost </address> 

--- a/ipi_tests/regression_tests/tests/INSTANTON/200K/input.xml
+++ b/ipi_tests/regression_tests/tests/INSTANTON/200K/input.xml
@@ -3,7 +3,7 @@
         <properties stride='1' filename='out'>  [ step, potential{electronvolt}] </properties>
    </output>
    <prng>
-      <seed> 12345 </seed>
+      <seed> 123456 </seed>
    </prng>
    <total_steps>100       </total_steps>
    <ffsocket name="doublewell_1D" mode="unix" >

--- a/ipi_tests/regression_tests/tests/INSTANTON/200K/input.xml
+++ b/ipi_tests/regression_tests/tests/INSTANTON/200K/input.xml
@@ -2,6 +2,9 @@
     <output prefix='simulation'>
         <properties stride='1' filename='out'>  [ step, potential{electronvolt}] </properties>
    </output>
+   <prng>
+      <seed> 12345 </seed>
+   </prng>
    <total_steps>100       </total_steps>
    <ffsocket name="doublewell_1D" mode="unix" >
        <address> localhost </address> 

--- a/ipi_tests/regression_tests/tests/NEB/DAMPED_BFGS/zundel/input.xml
+++ b/ipi_tests/regression_tests/tests/NEB/DAMPED_BFGS/zundel/input.xml
@@ -13,7 +13,7 @@
     <properties stride='1' filename='neb'> [step, bead_potentials] </properties>
   </output>
   <prng>
-      <seed> 12345 </seed>
+      <seed> 123456 </seed>
    </prng>
   <system>
     <forces>

--- a/ipi_tests/regression_tests/tests/NEB/DAMPED_BFGS/zundel/input.xml
+++ b/ipi_tests/regression_tests/tests/NEB/DAMPED_BFGS/zundel/input.xml
@@ -12,6 +12,9 @@
     <trajectory stride='1' filename='for' cell_units='angstrom'> forces </trajectory>
     <properties stride='1' filename='neb'> [step, bead_potentials] </properties>
   </output>
+  <prng>
+      <seed> 12345 </seed>
+   </prng>
   <system>
     <forces>
       <force forcefield='zundel'/>

--- a/ipi_tests/regression_tests/tests/NEB/FIRE/zundel/input.xml
+++ b/ipi_tests/regression_tests/tests/NEB/FIRE/zundel/input.xml
@@ -7,6 +7,9 @@
     <timeout> 600 </timeout>
     <address> localhost </address>
   </ffsocket>
+ <prng>
+      <seed> 12345 </seed>
+   </prng>
   <output prefix='simulation'>
     <trajectory stride='1' filename='pos' cell_units='angstrom'> positions{angstrom} </trajectory>
     <trajectory stride='1' filename='for' cell_units='angstrom'> forces </trajectory>

--- a/ipi_tests/regression_tests/tests/NEB/FIRE/zundel/input.xml
+++ b/ipi_tests/regression_tests/tests/NEB/FIRE/zundel/input.xml
@@ -8,7 +8,7 @@
     <address> localhost </address>
   </ffsocket>
  <prng>
-      <seed> 12345 </seed>
+      <seed> 123456 </seed>
    </prng>
   <output prefix='simulation'>
     <trajectory stride='1' filename='pos' cell_units='angstrom'> positions{angstrom} </trajectory>

--- a/ipi_tests/regression_tests/tests/PHONONS/fd_phonons/ch4hcbe-with_fixdofs/input.xml
+++ b/ipi_tests/regression_tests/tests/PHONONS/fd_phonons/ch4hcbe-with_fixdofs/input.xml
@@ -3,6 +3,9 @@
         <properties stride='1' filename='out'>  [ step, potential{electronvolt}] </properties>
         <trajectory stride="1" filename="xc" format="xyz">x_centroid{angstrom}</trajectory>
    </output>
+   <prng>
+      <seed> 12345 </seed>
+   </prng>
    <total_steps>400       </total_steps>
    <ffsocket name="ch4cbe" mode="unix" >
        <address> localhost </address>

--- a/ipi_tests/regression_tests/tests/PHONONS/fd_phonons/ch4hcbe-with_fixdofs/input.xml
+++ b/ipi_tests/regression_tests/tests/PHONONS/fd_phonons/ch4hcbe-with_fixdofs/input.xml
@@ -4,7 +4,7 @@
         <trajectory stride="1" filename="xc" format="xyz">x_centroid{angstrom}</trajectory>
    </output>
    <prng>
-      <seed> 12345 </seed>
+      <seed> 123456 </seed>
    </prng>
    <total_steps>400       </total_steps>
    <ffsocket name="ch4cbe" mode="unix" >

--- a/ipi_tests/regression_tests/tests/PHONONS/fd_phonons/ch4hcbe/input.xml
+++ b/ipi_tests/regression_tests/tests/PHONONS/fd_phonons/ch4hcbe/input.xml
@@ -4,7 +4,7 @@
         <trajectory stride="1" filename="xc" format="xyz">x_centroid{angstrom}</trajectory>
    </output>
     <prng>
-      <seed> 12345 </seed>
+      <seed> 123456 </seed>
    </prng>
    <total_steps>400       </total_steps>
    <ffsocket name="ch4cbe" mode="unix" >

--- a/ipi_tests/regression_tests/tests/PHONONS/fd_phonons/ch4hcbe/input.xml
+++ b/ipi_tests/regression_tests/tests/PHONONS/fd_phonons/ch4hcbe/input.xml
@@ -3,6 +3,9 @@
         <properties stride='1' filename='out'>  [ step, potential{electronvolt}] </properties>
         <trajectory stride="1" filename="xc" format="xyz">x_centroid{angstrom}</trajectory>
    </output>
+    <prng>
+      <seed> 12345 </seed>
+   </prng>
    <total_steps>400       </total_steps>
    <ffsocket name="ch4cbe" mode="unix" >
        <address> localhost </address>

--- a/ipi_tests/regression_tests/tests/PLUMED/BIAS.NOAUTO/input.xml
+++ b/ipi_tests/regression_tests/tests/PLUMED/BIAS.NOAUTO/input.xml
@@ -7,7 +7,7 @@
     <trajectory stride="10" filename="rest" extra_type="rest.bias"> extras_bias </trajectory>
    </output>
    <prng>
-      <seed> 12345 </seed>
+      <seed> 123456 </seed>
    </prng>
    <total_steps> 100 </total_steps>
    <ffsocket name="pswater" mode="unix">

--- a/ipi_tests/regression_tests/tests/PLUMED/BIAS.NOAUTO/input.xml
+++ b/ipi_tests/regression_tests/tests/PLUMED/BIAS.NOAUTO/input.xml
@@ -6,6 +6,9 @@
     <trajectory stride="10" filename="cv" extra_type="dhh"> extras_bias </trajectory>
     <trajectory stride="10" filename="rest" extra_type="rest.bias"> extras_bias </trajectory>
    </output>
+   <prng>
+      <seed> 12345 </seed>
+   </prng>
    <total_steps> 100 </total_steps>
    <ffsocket name="pswater" mode="unix">
        <address> localhost </address> 

--- a/ipi_tests/regression_tests/tests/PLUMED/METAD.NOAUTO/input.xml
+++ b/ipi_tests/regression_tests/tests/PLUMED/METAD.NOAUTO/input.xml
@@ -5,6 +5,9 @@
     <trajectory stride="20" filename="frc_c" format="xyz"> f_centroid </trajectory>
     <trajectory stride="10" filename="dhh" extra_type="dhh"> extras_bias </trajectory>
    </output>
+   <prng>
+      <seed> 12345 </seed>
+   </prng>
    <total_steps> 100 </total_steps>
    <ffsocket name="pswater" mode="unix">
        <address> localhost </address> 

--- a/ipi_tests/regression_tests/tests/PLUMED/METAD.NOAUTO/input.xml
+++ b/ipi_tests/regression_tests/tests/PLUMED/METAD.NOAUTO/input.xml
@@ -6,7 +6,7 @@
     <trajectory stride="10" filename="dhh" extra_type="dhh"> extras_bias </trajectory>
    </output>
    <prng>
-      <seed> 12345 </seed>
+      <seed> 123456 </seed>
    </prng>
    <total_steps> 100 </total_steps>
    <ffsocket name="pswater" mode="unix">


### PR DESCRIPTION
Any old simulation that relied on the default prng seed can be reproduced by setting seed = 12345. This is documented in the help function of the prng seed attribute. This modification should remove the need of explicitly setting different seeds for different calculations. The seed used is reported in the standard output and written on restart and checkpoint files.

  I have modified input/prng.py and utils/prng.py. I updated all inputs in
  the regression tests for safety. Only the PLUMED ones were relying on the default
  seed 12345. The others were simulations where no random sequence should be generated,
  but I added the old default anyways.

  Tested behaviour in the output file and saving to restart files.