### PR TITLE
Making the dummy driver pass a json-formatted string for extras field

### DIFF
--- a/drivers/f90/driver.f90
+++ b/drivers/f90/driver.f90
@@ -1000,8 +1000,7 @@
                 CALL writebuffer(socket,initbuffer,cbuf)
                 IF (verbose > 1) WRITE(*,*) "    !write!=> extra: ",  &
      &          initbuffer(1:cbuf)
-!            ELSEIF (vstyle==5 .or. vstyle==6 .or. vstyle==8 .or. vstyle==99) THEN ! returns the  dipole through initbuffer
-            ELSEIF (vstyle==5 .or. vstyle==6 .or. vstyle==8) THEN ! returns the  dipole through initbuffer
+            ELSEIF (vstyle==5 .or. vstyle==6 .or. vstyle==8 .or. vstyle==99) THEN ! returns the  dipole through initbuffer
                WRITE(initbuffer, '(a,3x,f15.8,a,f15.8,a,f15.8, &
      &         3x,a)') '{"dipole": [',dip(1),",",dip(2),",",dip(3),"]}"
                cbuf = LEN_TRIM(initbuffer)

--- a/drivers/py/pes/dummy.py
+++ b/drivers/py/pes/dummy.py
@@ -4,6 +4,7 @@ __DRIVER_CLASS__ = "Dummy_driver"
 
 import json
 
+
 class Dummy_driver(object):
     """Base class providing the structure of a PES for the python driver."""
 
@@ -25,5 +26,7 @@ class Dummy_driver(object):
         pot = 0.0
         force = pos * 0.0  # makes a zero force with same shape as pos
         vir = cell * 0.0  # makes a zero virial with same shape as cell
-        extras = json.dumps({"dipole": [0.0, 0.0, 0.0]}) # have json formatting to potentially work with some test examples. meaningless value
+        extras = json.dumps(
+            {"dipole": [0.0, 0.0, 0.0]}
+        )  # have json formatting to potentially work with some test examples. meaningless value
         return pot, force, vir, extras

--- a/drivers/py/pes/dummy.py
+++ b/drivers/py/pes/dummy.py
@@ -2,6 +2,7 @@
 __DRIVER_NAME__ = "dummy"
 __DRIVER_CLASS__ = "Dummy_driver"
 
+import json
 
 class Dummy_driver(object):
     """Base class providing the structure of a PES for the python driver."""
@@ -24,5 +25,5 @@ class Dummy_driver(object):
         pot = 0.0
         force = pos * 0.0  # makes a zero force with same shape as pos
         vir = cell * 0.0  # makes a zero virial with same shape as cell
-        extras = "nada"
+        extras = json.dumps({"dipole": [0.0, 0.0, 0.0]}) # have json formatting to potentially work with some test examples. meaningless value
         return pot, force, vir, extras

--- a/ipi_tests/examples/excluded_test.txt
+++ b/ipi_tests/examples/excluded_test.txt
@@ -8,7 +8,7 @@ temp/ph2/rpmd   # long and complicated
 
 # Needs infrastructure fixing
 
-clients/fhi_aims/zundel                        # dummy driver has an issue with extra_type. example works with actual backends.
+# clients/fhi_aims/zundel                        # dummy driver has an issue with extra_type. example works with actual backends.
 
 # Need of external dependency
 clients/yaff/mil53_ffyaff

--- a/ipi_tests/examples/excluded_test.txt
+++ b/ipi_tests/examples/excluded_test.txt
@@ -8,8 +8,6 @@ temp/ph2/rpmd   # long and complicated
 
 # Needs infrastructure fixing
 
-# clients/fhi_aims/zundel                        # dummy driver has an issue with extra_type. example works with actual backends.
-
 # Need of external dependency
 clients/yaff/mil53_ffyaff
 clients/yaff/mil53_ffsocket


### PR DESCRIPTION
Enables testing with python or f90 driver for examples where extra_type is needed.