### PR TITLE
Removing drift from conserved quantity.

### DIFF
--- a/ipi/engine/ensembles.py
+++ b/ipi/engine/ensembles.py
@@ -264,7 +264,14 @@ class Ensemble:
         for e in self._elist:
             eham += e.get()
 
-        print('kin, pot, eens, eget, total',self.nm.kin, self.forces.pot, self.eens, eham-self.nm.kin-self.forces.pot, self.nm.kin+ self.forces.pot)
+        print(
+            "kin, pot, eens, eget, total",
+            self.nm.kin,
+            self.forces.pot,
+            self.eens,
+            eham - self.nm.kin - self.forces.pot,
+            self.nm.kin + self.forces.pot,
+        )
         return eham + self.eens
 
     def get_lpens(self):

--- a/ipi/engine/ensembles.py
+++ b/ipi/engine/ensembles.py
@@ -264,6 +264,7 @@ class Ensemble:
         for e in self._elist:
             eham += e.get()
 
+        print('kin, pot, eens, eget, total',self.nm.kin, self.forces.pot, self.eens, eham-self.nm.kin-self.forces.pot, self.nm.kin+ self.forces.pot)
         return eham + self.eens
 
     def get_lpens(self):

--- a/ipi/engine/ensembles.py
+++ b/ipi/engine/ensembles.py
@@ -264,14 +264,14 @@ class Ensemble:
         for e in self._elist:
             eham += e.get()
 
-        print(
-            "kin, pot, eens, eget, total",
-            self.nm.kin,
-            self.forces.pot,
-            self.eens,
-            eham - self.nm.kin - self.forces.pot,
-            self.nm.kin + self.forces.pot,
-        )
+        #        print(
+        #            "kin, pot, eens, eget, total",
+        #            self.nm.kin,
+        #            self.forces.pot,
+        #            self.eens,
+        #            eham - self.nm.kin - self.forces.pot,
+        #            self.nm.kin + self.forces.pot,
+        #        )
         return eham + self.eens
 
     def get_lpens(self):

--- a/ipi/engine/ensembles.py
+++ b/ipi/engine/ensembles.py
@@ -264,14 +264,6 @@ class Ensemble:
         for e in self._elist:
             eham += e.get()
 
-        #        print(
-        #            "kin, pot, eens, eget, total",
-        #            self.nm.kin,
-        #            self.forces.pot,
-        #            self.eens,
-        #            eham - self.nm.kin - self.forces.pot,
-        #            self.nm.kin + self.forces.pot,
-        #        )
         return eham + self.eens
 
     def get_lpens(self):

--- a/ipi/engine/motion/dynamics.py
+++ b/ipi/engine/motion/dynamics.py
@@ -221,6 +221,11 @@ class Dynamics(Motion):
             elif self.enstype == "nst":
                 if np.allclose(self.ensemble.stressext.diagonal(), -12345):
                     raise ValueError("Unspecified stress for a constant-s integrator")
+        if self.enstype == "nve" and self.beads.nbeads > 1:
+            if self.ensemble.temp < 0:
+                raise ValueError(
+                    "You need to provide a positive value for temperature inside ensemble to run a PIMD simulation, even when choosing NVE propagation."
+                )
 
     def get_ntemp(self):
         """Returns the PI simulation temperature (P times the physical T)."""

--- a/ipi/engine/motion/dynamics.py
+++ b/ipi/engine/motion/dynamics.py
@@ -288,8 +288,12 @@ class DummyIntegrator:
         self._dt = motion._dt
         self._nmts = motion._nmts
 
-        # calculate active atoms
-        full_indices = np.arange(len(self.beads.p[0]))
+        # check whether fixed indexes make sense
+        if np.any(self.fixatoms_dof >= (3*self.beads.natoms)):   
+            raise ValueError("Constrained indexes are out of bounds wrt. number of atoms.")
+
+        # calculate active dofs
+        full_indices = np.arange(3*self.beads.natoms)
         self.activeatoms_dof = np.setdiff1d(full_indices, self.fixatoms_dof)
 
         # total number of iteration in the inner-most MTS loop

--- a/ipi/engine/motion/dynamics.py
+++ b/ipi/engine/motion/dynamics.py
@@ -296,7 +296,10 @@ class DummyIntegrator:
 
         # calculate active dofs
         full_indices = np.arange(3 * self.beads.natoms)
-        self.activeatoms_dof = np.setdiff1d(full_indices, self.fixatoms_dof)
+        # in the next line, we check whether the fixed indexes are in the full indexes and invert the boolean result with the tilde
+        mask = ~np.isin(full_indices, self.fixatoms_dof)
+        # these are the active indexes determined without sorting, which is faster
+        self.activeatoms_dof = full_indices[mask]
 
         # total number of iteration in the inner-most MTS loop
         self._inmts = depend_value(name="inmts", func=lambda: np.prod(self.nmts))

--- a/ipi/engine/motion/dynamics.py
+++ b/ipi/engine/motion/dynamics.py
@@ -297,9 +297,7 @@ class DummyIntegrator:
         # calculate active dofs
         full_indices = np.arange(3 * self.beads.natoms)
         # in the next line, we check whether the fixed indexes are in the full indexes and invert the boolean result with the tilde
-        mask = ~np.isin(full_indices, self.fixatoms_dof)
-        # these are the active indexes determined without sorting, which is faster
-        self.activeatoms_dof = full_indices[mask]
+        self.activeatoms_mask = ~np.isin(full_indices, self.fixatoms_dof)
 
         # total number of iteration in the inner-most MTS loop
         self._inmts = depend_value(name="inmts", func=lambda: np.prod(self.nmts))
@@ -417,13 +415,13 @@ class NVEIntegrator(DummyIntegrator):
         """Velocity Verlet momentum propagator."""
 
         # halfdt/alpha
-        self.beads.p[:, self.activeatoms_dof] += (
-            dstrip(self.forces.mts_forces[level].f)[:, self.activeatoms_dof]
+        self.beads.p[:, self.activeatoms_mask] += (
+            dstrip(self.forces.mts_forces[level].f)[:, self.activeatoms_mask]
             * self.pdt[level]
         )
         if level == 0 and self.ensemble.has_bias:  # adds bias in the outer loop
-            self.beads.p[:, self.activeatoms_dof] += (
-                dstrip(self.bias.f)[:, self.activeatoms_dof] * self.pdt[level]
+            self.beads.p[:, self.activeatoms_mask] += (
+                dstrip(self.bias.f)[:, self.activeatoms_mask] * self.pdt[level]
             )
 
     def qcstep(self):

--- a/ipi/engine/motion/dynamics.py
+++ b/ipi/engine/motion/dynamics.py
@@ -370,7 +370,6 @@ class DummyIntegrator:
         if len(self.fixatoms_dof) > 0:
             m3 = dstrip(beads.m3)
             p = dstrip(beads.p)
-            print("momsquare ", p[:, self.fixatoms_dof] ** 2)
             self.ensemble.eens += 0.5 * np.sum(
                 p[:, self.fixatoms_dof] ** 2 / m3[:, self.fixatoms_dof]
             )

--- a/ipi/engine/motion/dynamics.py
+++ b/ipi/engine/motion/dynamics.py
@@ -370,11 +370,12 @@ class DummyIntegrator:
         if len(self.fixatoms_dof) > 0:
             m3 = dstrip(beads.m3)
             p = dstrip(beads.p)
-            print('momsquare ', p[:, self.fixatoms_dof] ** 2)
+            print("momsquare ", p[:, self.fixatoms_dof] ** 2)
             self.ensemble.eens += 0.5 * np.sum(
                 p[:, self.fixatoms_dof] ** 2 / m3[:, self.fixatoms_dof]
             )
             beads.p[:, self.fixatoms_dof] = 0.0
+
 
 dproperties(
     DummyIntegrator,
@@ -403,9 +404,14 @@ class NVEIntegrator(DummyIntegrator):
         """Velocity Verlet momentum propagator."""
 
         # halfdt/alpha
-        self.beads.p[:, self.activeatoms_dof] += dstrip(self.forces.mts_forces[level].f)[:, self.activeatoms_dof] * self.pdt[level]
+        self.beads.p[:, self.activeatoms_dof] += (
+            dstrip(self.forces.mts_forces[level].f)[:, self.activeatoms_dof]
+            * self.pdt[level]
+        )
         if level == 0 and self.ensemble.has_bias:  # adds bias in the outer loop
-            self.beads.p[:, self.activeatoms_dof] += dstrip(self.bias.f)[:, self.activeatoms_dof] * self.pdt[level]
+            self.beads.p[:, self.activeatoms_dof] += (
+                dstrip(self.bias.f)[:, self.activeatoms_dof] * self.pdt[level]
+            )
 
     def qcstep(self):
         """Velocity Verlet centroid position propagator."""

--- a/ipi/engine/motion/dynamics.py
+++ b/ipi/engine/motion/dynamics.py
@@ -289,11 +289,13 @@ class DummyIntegrator:
         self._nmts = motion._nmts
 
         # check whether fixed indexes make sense
-        if np.any(self.fixatoms_dof >= (3*self.beads.natoms)):   
-            raise ValueError("Constrained indexes are out of bounds wrt. number of atoms.")
+        if np.any(self.fixatoms_dof >= (3 * self.beads.natoms)):
+            raise ValueError(
+                "Constrained indexes are out of bounds wrt. number of atoms."
+            )
 
         # calculate active dofs
-        full_indices = np.arange(3*self.beads.natoms)
+        full_indices = np.arange(3 * self.beads.natoms)
         self.activeatoms_dof = np.setdiff1d(full_indices, self.fixatoms_dof)
 
         # total number of iteration in the inner-most MTS loop


### PR DESCRIPTION
Starting to address the problems reported in #422 . Need to check and discuss whether this fix is general.
In the NVE step I propagate the momenta only of the active dofs (not of the fixed ones). 

This is in draft stage, there are debugging print statements left. Still did not check many simulation types and combinations.