### PR TITLE
Fixed-D

### DIFF
--- a/ipi/pes/ase.py
+++ b/ipi/pes/ase.py
@@ -1,5 +1,6 @@
 """Interface with ASE calculators"""
 
+import json
 import numpy as np
 from .dummy import Dummy_driver
 
@@ -81,15 +82,28 @@ class ASEDriver(Dummy_driver):
         structure.calc = self.ase_calculator
 
         # Do the actual calculation
-        properties = structure.get_properties(self.capabilities)
+        self.ase_calculator.calculate(structure)
+        properties = self.ase_calculator.results
+        # properties = structure.get_properties(self.capabilities)
 
-        pot = properties["energy"] if "energy" in self.capabilities else 0.0
-        force = (
-            properties["forces"]
-            if "forces" in self.capabilities
-            else np.zeros_like(pos)
-        )
-        stress = properties["stress"] if "stress" in self.capabilities else np.zeros(9)
+        if "energy" in self.capabilities:
+            pot = properties["energy"]
+            del properties["energy"]
+        else:
+            pot = 0.0
+
+        if "forces" in self.capabilities:
+            force = properties["forces"]
+            del properties["forces"]
+        else:
+            force = np.zeros_like(pos)
+
+        if "stress" in self.capabilities:
+            stress = properties["stress"]
+            del properties["stress"]
+        else:
+            stress = np.zeros(9)
+
         if len(stress) == 6:
             # converts from voight notation
             stress = np.array(stress[[0, 5, 4, 5, 1, 3, 4, 3, 2]])
@@ -103,6 +117,27 @@ class ASEDriver(Dummy_driver):
         vir_ipi = np.array(
             unit_to_internal("energy", "electronvolt", vir_calc.T), dtype=np.float64
         )
-        extras = ""
+        extras = json.dumps(properties, cls=NumpyEncoder)
 
         return pot_ipi, force_ipi, vir_ipi, extras
+
+
+# ---------------------------------------#
+class NumpyEncoder(json.JSONEncoder):
+    """
+    Custom JSON encoder to handle NumPy arrays.
+
+    This encoder converts NumPy arrays into Python lists, ensuring compatibility
+    with the JSON serialization format.
+
+    Example:
+        >>> import numpy as np
+        >>> data = {"array": np.array([1, 2, 3])}
+        >>> json.dumps(data, cls=NumpyEncoder)
+        '{"array": [1, 2, 3]}'
+    """
+
+    def default(self, obj):
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()  # Convert NumPy array to list
+        return super().default(obj)

--- a/ipi/pes/mace_dielectric.py
+++ b/ipi/pes/mace_dielectric.py
@@ -5,7 +5,7 @@ import json
 import numpy as np
 from .mace import MACE_driver
 from ipi.utils.messages import warning
-from ipi.utils.units import unit_to_internal, unit_to_user
+from ipi.utils.units import unit_to_internal
 
 MACECalculator = None
 

--- a/ipi/pes/mace_dielectric.py
+++ b/ipi/pes/mace_dielectric.py
@@ -1,0 +1,153 @@
+""" An interface for the [MACE](https://github.com/ACEsuit/mace) calculator to get dielectric properties"""
+
+import os
+import json
+import numpy as np
+from .mace import MACE_driver
+from ipi.utils.messages import warning
+from ipi.utils.units import unit_to_internal, unit_to_user
+
+MACECalculator = None
+
+__DRIVER_NAME__ = "mace_dielectric"
+__DRIVER_CLASS__ = "MACE_dielectric_driver"
+
+METHODS_AVAILABLE = [
+    "fixed-D",  # https://doi.org/10.1103/PhysRevB.93.144201
+    "fixed-E",  # https://doi.org/10.48550/arXiv.2502.02413
+    "none",  # just for debugging purposes
+]
+
+# ToDo:
+# - check the units of the electric displacement
+# - write fixed_D
+
+
+class MACE_dielectric_driver(MACE_driver):
+
+    method: str
+    instructions: str
+
+    def __init__(self, method: str, instructions: str, *args, **kwargs):
+        """Driver for the MACE MLIPs to compute dielectric properties."""
+
+        super().__init__(*args, **kwargs)
+
+        method = str(method)
+        instructions = str(instructions)
+
+        if method not in METHODS_AVAILABLE:
+            raise ValueError(f"method must be one of {METHODS_AVAILABLE}")
+        if not os.path.exists(instructions):
+            raise ValueError(f"File '{instructions}' does not exist.")
+        if not str(instructions).endswith(".json"):
+            raise ValueError(f"File '{instructions}' must be a json file.")
+
+        self.method = method
+
+        with open(instructions, "r") as f:
+            tmp_data = json.load(f)
+
+        # ------------------------------ #
+        # fixed electric field (E)
+        if self.method == "fixed-E":
+
+            # 'instructions' must contain the following
+            # {
+            #     "E": 0.4,          // mandatory
+            #     "E-unit": "V/ang", // optional (default: atomic_unit)
+            # }
+
+            if "E" not in tmp_data:
+                raise ValueError(
+                    f"File '{instructions}' must contain 'E' for method 'fixed-E'."
+                )
+            if "E-unit" not in tmp_data:
+                warning(
+                    f"File '{instructions}' does not contain 'E-unit': we will be assumed that 'E' is in 'atomic_unit'."
+                )
+                tmp_data["E-unit"] = "atomic_unit"
+
+            E = unit_to_internal("electric-field", tmp_data["E-unit"], tmp_data["E"])
+            self.instructions = {
+                "E": E,
+            }
+
+        # ------------------------------ #
+        # fixed electric displacement (D)
+        elif self.method == "fixed-D":
+
+            # 'instructions' must contain the following
+            # {
+            #     "D": 4,           // mandatory
+            #     "D-unit": "eang", // optional (default: atomic_unit)
+            #     "V": 123,         // mandatory
+            #     "V-unit": "ang3"  // optional (default: atomic_unit)
+            # }
+
+            if "D" not in self.instructions:
+                raise ValueError(
+                    f"File '{instructions}' must contain 'D' (electric displacement) for method 'fixed-D'."
+                )
+            if "D-unit" not in self.instructions:
+                warning(
+                    f"File '{instructions}' does not contain 'D-unit' (electric displacement unit): we will assumed that 'D' is in 'atomic_unit'."
+                )
+                tmp_data["D-unit"] = "atomic_unit"
+            if "V" not in self.instructions:
+                raise ValueError(
+                    f"File '{instructions}' must contain 'V' (volume) for method 'fixed-D'."
+                )
+            if "V-unit" not in self.instructions:
+                warning(
+                    f"File '{instructions}' does not contain 'volume' (volume unit): we will assumed that 'volume' is in 'atomic_unit'."
+                )
+                tmp_data["V-unit"] = "atomic_unit"
+
+            D = unit_to_internal("bo", tmp_data["D-unit"], tmp_data["D"])
+            V = unit_to_internal("volume", tmp_data["V-unit"], tmp_data["V"])
+            self.instructions = {
+                "D": D,
+                "V": V,
+            }
+
+    def __call__(self, cell, pos):
+
+        pot_ipi, force_ipi, vir_ipi, extras_ipi = super().__call__(cell, pos)
+
+        # just returns what provided by the MACE model
+        if self.method == "none":
+            return pot_ipi, force_ipi, vir_ipi, extras_ipi
+
+        # add the contribution to the fixed electric field (E) to the potential and forces
+        elif self.method == "fixed-E":
+            pot, force, vir, extras = fixed_E(extras_ipi, self.instructions["E"])
+
+        # add the contribution to the fixed electric displacement (D) to the potential and forces
+        elif self.method == "fixed-D":
+            pot, force, vir, extras = fixed_D(
+                extras_ipi, self.instructions["D"], self.instructions["V"]
+            )
+
+        else:  # should never reach here
+            raise ValueError(
+                f"This is an implementation error. 'method' = {self.method} but it should be one of {METHODS_AVAILABLE}."
+            )
+
+        pot_ipi += pot
+        force_ipi += force
+        vir_ipi += vir
+        extras_ipi = {**extras_ipi, **extras}
+
+        return pot_ipi, force_ipi, vir_ipi, extras_ipi
+
+
+def fixed_E(extras: dict, Efield: np.ndarray):
+    pot = -np.asarray(extras["dipole"]) @ Efield
+    force = extras["BEC"] @ Efield
+    vir = np.zeros((3, 3))
+    return pot, force, vir, extras
+
+
+def fixed_D(extras: dict, displacement: np.ndarray, volume: np.ndarray):
+    return None


### PR DESCRIPTION
A new driver for `MACE` models predicting dipoles and Born charges (and eventually energy and forces) to implement ensembles at **constant** external electric field E or electric displacement D.

The implementation can be optimized if it were possible to ask the MACE model **not** to compute the forces, so that the driver will add to the energy the interaction term (at fixed E or fixed D) and evaluate the forces only afterwards.
This would allow to call `pytorch.autograd` only once (for the total energy/enthalpy) instead of 4 times, i.e. once for the energy predicted by the model and 3 times for each component of the dipole.
This might be not totally independent on the MACE code.

Moreover, this PR is not fully disentangled/uncorrelated by the `PSwater-pytorch` PR.