### PR TITLE
Deprecate PET and librascal drivers

### DIFF
--- a/ipi/pes/pet.py
+++ b/ipi/pes/pet.py
@@ -45,6 +45,8 @@ class PET_driver(Dummy_driver):
         except ImportError:
             raise ImportError("Could not find or import the PET module")
 
+        warning("PET driver is deprecated and will be removed in the next release.")
+
         self.model_path = model_path
         self.template = template
         super().__init__(*args, **kwargs)

--- a/ipi/pes/rascal.py
+++ b/ipi/pes/rascal.py
@@ -36,8 +36,13 @@ class Rascal_driver(Dummy_driver):
         )
         try:
             from rascal.models.genericmd import GenericMDCalculator as RascalCalc
-        except:
+        except ImportError:
             raise ImportError("Couldn't load librascal bindings")
+
+        warning(
+            "librascal driver is deprecated and will be removed in the next release."
+        )
+
         self.model = model
         self.template = template
 


### PR DESCRIPTION
There are new implementations of both that are actively maintained