### PR TITLE
Fix vesin device

### DIFF
--- a/ipi/pes/metatensor.py
+++ b/ipi/pes/metatensor.py
@@ -182,19 +182,15 @@ class MetatensorDriver(Dummy_driver):
         positions = unit_to_user("length", "angstrom", pos)
         cell = unit_to_user("length", "angstrom", cell.T)
 
-        positions = torch.from_numpy(positions).to(
-            dtype=self._dtype, device=self.device
-        )
-        cell = torch.from_numpy(cell).to(dtype=self._dtype, device=self.device)
+        positions = torch.from_numpy(positions).to(dtype=self._dtype)
+        cell = torch.from_numpy(cell).to(dtype=self._dtype)
         pbc = torch.norm(cell, dim=1) != 0.0
 
         if not self.non_conservative:
             positions.requires_grad_(True)
             # this is to compute the virial (which is related to the derivative with
             # respect to the strain)
-            strain = torch.eye(
-                3, requires_grad=True, device=self.device, dtype=self._dtype
-            )
+            strain = torch.eye(3, requires_grad=True, dtype=self._dtype)
             positions = positions @ strain
             cell = cell @ strain
 
@@ -203,6 +199,7 @@ class MetatensorDriver(Dummy_driver):
         vesin_torch_metatensor.compute_requested_neighbors(
             system, system_length_unit="A", model=self.model
         )
+        system = system.to(self.device)
 
         outputs = self.model(
             [system],

--- a/ipi/pes/metatensor.py
+++ b/ipi/pes/metatensor.py
@@ -140,9 +140,7 @@ class MetatensorDriver(Dummy_driver):
 
         # read the template and extract the corresponding atomic types
         atoms = ase.io.read(self.template)
-        self._types = torch.from_numpy(atoms.numbers).to(
-            device=self.device, dtype=torch.int32
-        )
+        self._types = torch.from_numpy(atoms.numbers).to(dtype=torch.int32)
 
         # Register the requested outputs
         outputs = {"energy": mta.ModelOutput(quantity="energy", unit="eV")}


### PR DESCRIPTION
For some reason, vesin can't handle non-CPU devices anymore (@Luthaf?). This new design sends the system to the GPU after the NL calculation, avoiding the bug (and a CPU-GPU-CPU trip if the bug wasn't there)