### PR TITLE
Added (and cleaned) debug messages around FF evaluation and depend objects

### DIFF
--- a/ipi/engine/forcefields.py
+++ b/ipi/engine/forcefields.py
@@ -483,6 +483,7 @@ class FFDirect(FFEval):
 
         request["result"] = results
         request["status"] = "Done"
+        request["t_finished"] = time.time()
 
 
 class FFLennardJones(FFEval):

--- a/ipi/engine/forces.py
+++ b/ipi/engine/forces.py
@@ -192,7 +192,7 @@ class ForceBead:
 
         # print diagnostics about the elapsed time
         info(
-            "# forcefield %s evaluated in %f (queue) and %f (dispatched) sec."
+            " @forces: FF %s evaluated in %f (queue) and %f (dispatched) sec."
             % (
                 self.ff.name,
                 request["t_finished"] - request["t_queued"],

--- a/ipi/utils/depend.py
+++ b/ipi/utils/depend.py
@@ -31,7 +31,7 @@ from copy import deepcopy
 
 import numpy as np
 
-from ipi.utils.messages import verbosity, warning
+from ipi.utils.messages import verbosity, warning, info
 
 
 __all__ = [
@@ -273,6 +273,7 @@ class depend_base(object):
         if self._synchro is not None:
             if not self._name == self._synchro.manual:
                 self.set(self._func[self._synchro.manual](), manual=False)
+                info(f" @depend: Set value for {self._name} (syncro)", verbosity.debug)
             else:
                 warning(
                     self._name + " probably shouldn't be tainted (synchro)",
@@ -280,6 +281,7 @@ class depend_base(object):
                 )
         elif self._func is not None:
             self.set(self._func(), manual=False)
+            info(f" @depend: Set value for {self._name} (auto)", verbosity.debug)
         else:
             warning(
                 self._name + " probably shouldn't be tainted (value)", verbosity.low
@@ -298,6 +300,7 @@ class depend_base(object):
 
         if self._synchro is not None:
             self._synchro.manual = self._name
+            info(f" @depend: Set value for {self._name} (manual)", verbosity.debug)
         elif self._func is not None:
             raise NameError(
                 "Cannot set manually the value of the automatically-computed property <"


### PR DESCRIPTION
Sometimes it's not clear when and why the potential gets called. This PR introduces some messages (printed only with DEBUG verbosity) to help debug calls triggered by depend updates.