### PR TITLE
Update xml dictionary parser to permit GPU selection in "ffdirect" metatomic

### DIFF
--- a/ipi/utils/io/inputs/io_xml.py
+++ b/ipi/utils/io/inputs/io_xml.py
@@ -480,7 +480,7 @@ def read_dict(data, delims="{}", split=",", key_split=":", strip=" \n\t"):
 
     rdict = {}
     for s in rlist:
-        rtuple = list(map(mystrip, s.split(key_split)))
+        rtuple = list(map(mystrip, s.split(key_split, 1)))
         if not len(rtuple) == 2:
             raise ValueError("Format for a key:value format is wrong for item " + s)
         rdict[rtuple[0]] = read_value(rtuple[1])


### PR DESCRIPTION
Currently it is not permissible to specify the cuda device for metatomic models in ffdirect mode:

```
  <ffdirect name='pbe'>
      <pes> metatomic </pes>
  <parameters> {template:init.xyz,model:pbe.pt,device:cuda:0 } </parameters> 
  </ffdirect>
```

will result in an incorrect split of the key value pair device:cuda:0

Adapting the parser to only split between the first occurence of ":" fixes the issue in my tests.