### PR TITLE
Fix #477: Warn user if 'mass' is used instead of 'masses' in extxyz

### DIFF
--- a/ipi/utils/io/backends/io_ase.py
+++ b/ipi/utils/io/backends/io_ase.py
@@ -109,9 +109,11 @@ def read_ase(filedesc):
 
     # Issue #477 fix
     if "mass" in atoms.arrays and "masses" not in atoms.arrays:
-        raise RuntimeError("ASE reader found 'mass' array but will ignore it. "
+        raise RuntimeError(
+            "ASE reader found 'mass' array but will ignore it. "
             "Rename column to 'masses' if you want to read custom atomic masses, "
-            "or remove it to use default atomic masses.")
+            "or remove it to use default atomic masses."
+        )
 
     if all(atoms.get_pbc()):
         # We want to make the cell conform


### PR DESCRIPTION
Fixes #477.

The issue is caused by ASE's get_masses() function, which strictly looks for an array named 'masses' and ignores 'mass'. This led to silent errors where custom masses were ignored without the user knowing.

This PR adds a check to explicitly warn the user if the input file contains 'mass' but not 'masses', helping them catch this formatting error immediately. 

Please let me know if there are any further issues or require further clarification. 

Best wishes,
Bohaz