### PR TITLE
Fix action to execute 24.04

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             python-version: "3.8"
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             python-version: "3.12"
 
     steps:


### PR DESCRIPTION
There is a missing action to run examples with 24.04