### PR TITLE
Some updates of the metatomic module

### DIFF
--- a/examples/clients/ase_client/aims/run_ase.py
+++ b/examples/clients/ase_client/aims/run_ase.py
@@ -27,7 +27,7 @@ workdir = "aims_rundir"
 aux_settings = {"label": workdir}
 calc = Aims(**usr_settings, **dft_settings, **aux_settings)
 
-atoms.set_calculator(calc)
+atoms.calc = calc
 
 # Create Client ############################
 # inet

--- a/ipi/pes/metatomic.py
+++ b/ipi/pes/metatomic.py
@@ -193,6 +193,7 @@ class MetatomicDriver(Dummy_driver):
         # to ensure compatibility with single-device methods
         self.model = self.models[0]
         self.device = self.devices[0]
+        self._nl_calculators = vesin_metatomic.neighbor_lists_for_model("A", self.model)
 
         self._dtype = getattr(torch, self.model.capabilities().dtype)
 
@@ -296,9 +297,8 @@ class MetatomicDriver(Dummy_driver):
         system = system.to(device)
 
         # Compute neighbor lists using vesin
-        vesin_metatomic.compute_requested_neighbors(
-            system, system_length_unit="Angstrom", model=model
-        )
+        for calculator in self._nl_calculators:
+            calculator.add_neighbor_list(system)
 
         return system, strain
 
@@ -640,8 +640,7 @@ class MetatomicDriver(Dummy_driver):
             pre_time += time()
 
             info(
-                "Total compute time %e (samples: %d; devices: %d)"
-                % (pre_time, n_samples, n_devices),
+                "Total compute time %e" % (pre_time),
                 verbosity.high,
             )
 

--- a/ipi/pes/metatomic.py
+++ b/ipi/pes/metatomic.py
@@ -153,9 +153,10 @@ class MetatomicDriver(Dummy_driver):
         metatomic_minor = int(metatomic_minor)
 
         if metatomic_major != 0 or metatomic_minor != 1:
-            raise ImportError(
-                "this code is only compatible with metatomic-torch == v0.1, "
-                f"found version v{mta.__version__} at '{mta.__file__}'"
+            warning(
+                "this code is only tested with metatomic-torch == v0.1, "
+                f"found version v{mta.__version__} at '{mta.__file__}'.\n"
+                "proceed at your own risk"
             )
 
     def _check_consistency_options(self):


### PR DESCRIPTION
1. Applied [the neighbor list calculator caching](https://github.com/Luthaf/vesin/commit/2ce4ca111372e65610e2109f62cc4ce3d242da25#diff-1ed1a7848e2057fb156fa15a63c126283d1bdb9150240d396c7af12e72a563d5) in i-pi, as discussed before
2. No longer raise an error when the version of metatomic-torch isn't v0.1, the same behavior as what introduced in https://github.com/Luthaf/vesin/commit/351904f740a88da610b3382365db042dc394544e