### PR TITLE
Allow for more readable file type in `FFPlumed`

### DIFF
--- a/ipi/engine/forcefields.py
+++ b/ipi/engine/forcefields.py
@@ -902,6 +902,12 @@ class FFPlumed(FFEval):
             mycell = myframe["cell"]
             myatoms.q *= unit_to_internal("length", self.init_file.units, 1.0)
             mycell.h *= unit_to_internal("length", self.init_file.units, 1.0)
+        else:
+            raise ValueError(
+                "Unsupported init file format for FFPlumed: "
+                + self.init_file.mode
+                + ". Supported formats are xyz, pdb and ase."
+            )
 
         self.natoms = myatoms.natoms
         self.plumed.cmd("setRealPrecision", 8)  # i-PI uses double precision

--- a/ipi/engine/forcefields.py
+++ b/ipi/engine/forcefields.py
@@ -895,7 +895,7 @@ class FFPlumed(FFEval):
         self.compute_work = compute_work
         self.init_file = init_file
 
-        if self.init_file.mode == "xyz":
+        if self.init_file.mode in ["xyz", "pdb", "ase"]:
             infile = open(self.init_file.value, "r")
             myframe = read_file(self.init_file.mode, infile)
             myatoms = myframe["atoms"]


### PR DESCRIPTION
`read_file` is used in initializing `FFPlumed`. It supports `xyz`, `pdb`, `ase`, and `chk`, while currently we only read when the mode is `xyz`. This PR allows for reading when the mode is `pdb` or `ase`, and throwing an error when the mode isn't `xyz`, `pdb`, or `ase` 

I didn't add `chk` because I know little about it, and I don't see why ppl would pass the `chk` file as the initial structure.