### PR TITLE
Allow for a more convenient restarting for `InteractiveSimulation` from `RESTART`

### DIFF
--- a/ipi/scripting/interactive.py
+++ b/ipi/scripting/interactive.py
@@ -57,6 +57,8 @@ class InteractiveSimulation(Simulation):
         self.__dict__.update(sim.__dict__)
 
     def _add_custom_properties(self, simulation):
+        # ensures that restarts for a finished simulation can be used
+        # without triggering immediate softexit
         simulation.tsteps = max(simulation.tsteps, simulation.step + 1)
 
         for name, property in self._custom_properties.items():

--- a/ipi/scripting/interactive.py
+++ b/ipi/scripting/interactive.py
@@ -57,6 +57,8 @@ class InteractiveSimulation(Simulation):
         self.__dict__.update(sim.__dict__)
 
     def _add_custom_properties(self, simulation):
+        simulation.tsteps = max(simulation.tsteps, simulation.step + 1)
+
         for name, property in self._custom_properties.items():
             # checks if properties have the right format
             if callable(property):


### PR DESCRIPTION
Currently when the simulation is run through `InteractiveSimulation`, in the `RESTART` file written at the end of the simulation, there won't be `<total_steps>`. If we try to restart the simulation from this `RESTART` file, due to the undefined `total_steps`, the simulation engine will use the default value 1000 for `total_steps` and finally lead to this error:
https://github.com/i-pi/i-pi/blob/5e66cd90d0fad9a3c2f918fe2b41726664553e4f/ipi/engine/simulation.py#L231-L235

This PR aims to modify the `total_steps` to be always greater than the steps stored in the `RESTART` file before initialize the `Simulation` class to avoid this error