### PR TITLE
Accessible version

### DIFF
--- a/ipi/__init__.py
+++ b/ipi/__init__.py
@@ -2,7 +2,7 @@
 The i-PI module.
 """
 
-__version__ = "3.2.0"
+__version__ = "unknown"
 
 # Python 3.8+:
 from importlib.metadata import version, PackageNotFoundError
@@ -10,7 +10,7 @@ from importlib.metadata import version, PackageNotFoundError
 try:
     __version__ = version("ipi")
 except PackageNotFoundError:
-    __version__ = "unknown"
+    __version__ = "3.2.0"
 
 ipi_global_settings = {"floatformat": "%16.8e"}
 

--- a/ipi/__init__.py
+++ b/ipi/__init__.py
@@ -2,6 +2,8 @@
 The i-PI module.
 """
 
+__version__ = "3.2.0"
+
 # Python 3.8+:
 from importlib.metadata import version, PackageNotFoundError
 

--- a/ipi_tests/unit_tests/test_version.py
+++ b/ipi_tests/unit_tests/test_version.py
@@ -1,6 +1,5 @@
 """Tests for ipi version handling."""
 
-import pytest
 import sys
 from importlib.metadata import PackageNotFoundError
 

--- a/ipi_tests/unit_tests/test_version.py
+++ b/ipi_tests/unit_tests/test_version.py
@@ -1,0 +1,42 @@
+"""Tests for ipi version handling."""
+
+import pytest
+import sys
+from importlib.metadata import PackageNotFoundError
+
+
+def test_version_from_package():
+    """Test that version is retrieved from installed package."""
+    import ipi
+
+    # When installed via pip, version should be accessible
+    assert ipi.__version__ is not None
+    assert len(ipi.__version__) > 0
+    assert ipi.__version__ != "unknown"
+
+
+def test_version_fallback_when_not_installed(monkeypatch):
+    """Test fallback to hardcoded version when PackageNotFoundError is raised.
+    
+    This test verifies that when importlib.metadata.version() fails,
+    the module still has a valid version (not "unknown").
+    """
+
+    def mock_version(package_name):
+        """Mock version() to simulate package not being installed."""
+        if package_name == "ipi":
+            raise PackageNotFoundError("ipi")
+        return package_name
+
+    monkeypatch.setattr("importlib.metadata.version", mock_version)
+
+    # Remove ipi from sys.modules to force reimport with the mocked version()
+    if "ipi" in sys.modules:
+        del sys.modules["ipi"]
+
+    import ipi as ipi_reimported
+
+    # The key assertion: version should NOT be "unknown"
+    # This proves the fallback to hardcoded version is working
+    assert ipi_reimported.__version__ != "unknown"
+    assert len(ipi_reimported.__version__) > 0

--- a/ipi_tests/unit_tests/test_version.py
+++ b/ipi_tests/unit_tests/test_version.py
@@ -17,7 +17,7 @@ def test_version_from_package():
 
 def test_version_fallback_when_not_installed(monkeypatch):
     """Test fallback to hardcoded version when PackageNotFoundError is raised.
-    
+
     This test verifies that when importlib.metadata.version() fails,
     the module still has a valid version (not "unknown").
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ipi
-version = 3.2.0
+version = attr: ipi.__version__
 description = A Python interface for ab initio path integral molecular dynamics simulations
 long_description = file: README.md
 long_description_content_type = text/x-rst


### PR DESCRIPTION
This grabs a feature of #419 that is very useful, even if we do not implement yet the more complex input versioning (which we are undecided about).

Now version is accessible from within the code and it is also available if i-PI is not installed from pip. Version bumps need to be changed in `ipi/__init__.py` 