### PR TITLE
Install driver in select scripts directories only

### DIFF
--- a/ipi/utils/setup.py
+++ b/ipi/utils/setup.py
@@ -46,7 +46,7 @@ def install_driver(force_install=False):
         if os_path is None or os_path == "":
             path_dirs = []
         else:
-            path_dirs = os_path.split(os.pathsep)
+            path_dirs = list(map(os.path.abspath, os_path.split(os.pathsep)))
 
         for directory in script_dirs:
             # check if the directory is on PATH and writable

--- a/ipi/utils/setup.py
+++ b/ipi/utils/setup.py
@@ -30,8 +30,8 @@ def install_driver(force_install=False):
     """
 
     ipi_path = get_ipi_path()
-    ipi_driver_path = shutil.which("i-pi-driver")
-    if ipi_driver_path is None or force_install:
+    ipi_driver_path = None if force_install else shutil.which("i-pi-driver")
+    if ipi_driver_path is None:
         import sysconfig
 
         # get potential installation locations for the driver

--- a/ipi/utils/setup.py
+++ b/ipi/utils/setup.py
@@ -29,9 +29,18 @@ def install_driver(force_install=False):
     Requires a system with git, gfortran and make.
     """
 
+    ipi_path = get_ipi_path()
     ipi_driver_path = shutil.which("i-pi-driver")
     if ipi_driver_path is None or force_install:
-        # this is where we'll copy the driver - the first writable folder
+        import sysconfig
+
+        # get potential installation locations for the driver
+        script_dirs = [
+            os.path.join(ipi_path, "bin"),  # preferred choice
+            sysconfig.get_path("scripts"),  # system, conda or virtual environment
+            sysconfig.get_path("scripts", sysconfig.get_preferred_scheme("user")),
+        ]
+
         os_path = os.getenv("PATH")
 
         if os_path is None or os_path == "":
@@ -39,9 +48,9 @@ def install_driver(force_install=False):
         else:
             path_dirs = os_path.split(os.pathsep)
 
-        for directory in path_dirs:
-            # Check if the directory is writable
-            if os.access(directory, os.W_OK):
+        for directory in script_dirs:
+            # check if the directory is on PATH and writable
+            if directory in path_dirs and os.access(directory, os.W_OK):
                 ipi_driver_path = os.path.join(directory, "i-pi-driver")
                 break
 
@@ -52,7 +61,6 @@ def install_driver(force_install=False):
         info(f"i-pi-driver is already present in {ipi_driver_path} ", verbosity.low)
         return
 
-    ipi_path = get_ipi_path()
     build_dir = os.path.join(ipi_path, "drivers/f90")
 
     if not os.path.exists(build_dir):


### PR DESCRIPTION
Hi all,

This should resolve #571.

Instead of trying any path on `PATH`, which could include locations unrelated to i-PI or the current Python environment, only three select paths are checked for (1) presence on `PATH` and (2) write access:

1. The `bin` directory in the i-PI root
2. The scripts directory of the conda or virtual environment (or system-wide Python installation)
3. The user-level scripts directory

The paths are not hard-coded but determined using the `sysconfig` package, which is in the standard library. Please note that `sysconfig.get_preferred_scheme()` used for the third option is only available since Python 3.10, which is the current lower bound for i-PI, so it should be fine.

If no suitable location is found, the driver is still installed in the current working directory. I do not know if this helps when using it for tutorials etc. since `i-pi-driver` is not the same as `./i-pi-driver`. Alternatively, an error could be raised. It might also be helpful to always print the chosen installation location.

I tested this by sourcing the following Bash script (`source test_ipi_install_driver.sh`), where `[placeholders]` are in square brackets:
```
conda deactivate # conda is on PATH but no environment active

source [path to repository]/i-pi/env.sh

echo "Installation in i-PI root"

python3 -c "import ipi; ipi.install_driver()" &> /dev/null
which i-pi-driver
rm $(which i-pi-driver)
unset IPI_ROOT # but we keep i-PI on PYTHONPATH

echo "Installation at user level"

python3 -c "import ipi; ipi.install_driver()" &> /dev/null
which i-pi-driver
rm $(which i-pi-driver)

echo "Installation in virtual environment"

python3 -m venv virtual_environment
source virtual_environment/bin/activate
python3 -m pip install -q numpy
python3 -c "import ipi; ipi.install_driver()" &> /dev/null
which i-pi-driver
deactivate
rm -r virtual_environment

echo "Installation in conda environment"

conda create -y -p conda_environment &> /dev/null
conda activate ./conda_environment
conda install -y numpy &> /dev/null
python3 -c "import ipi; ipi.install_driver()" &> /dev/null
which i-pi-driver
conda deactivate
rm -r conda_environment
```
The output is:
```
Setting up i-PI paths to base folder [path to repository]/i-pi
Installation in i-PI root
[path to repository]/i-pi/bin/i-pi-driver
Installation at user level
[home directory]/.local/bin/i-pi-driver
Installation in virtual environment
[current directory]/virtual_environment/bin/i-pi-driver
Installation in conda environment
[current directory]/conda_environment/bin/i-pi-driver
```
What do you think, @mahrossi? There are probably better options, but this should work in most cases.