### PR TITLE
updated defaults for coverage trigger threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,5 +8,12 @@ codecov:
     after_n_builds: 4
     wait_for_ci: true
 
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+
 comment:
   after_n_builds: 4

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 1%
+        threshold: 0.5%
 
 comment:
   after_n_builds: 4


### PR DESCRIPTION
so this sets the target (previously 80 % by default) to auto and a threshold of 1% so that adding couple of lines doesn't hinder a PR. 