### PR TITLE
fixed bug with initialization

### DIFF
--- a/ipi/engine/initializer.py
+++ b/ipi/engine/initializer.py
@@ -146,30 +146,21 @@ def init_chk(filename):
        filename: A string giving the name of the checkpoint file to be read from.
 
     Returns:
-       A Beads object, Cell object and Thermostat object as read from the
+       A Beads object, Cell object and Motion object as read from the
        checkpoint file.
     """
 
-    # reads configuration from a checkpoint file
-    rfile = open(filename, "r")
-    xmlchk = xml_parse_file(rfile)  # Parses the file.
+    # Parse only the state required by the initializer.  A full checkpoint
+    # restart still uses InputSimulation.fetch(), which intentionally restores
+    # its force fields as well.
+    with open(filename, "r") as rfile:
+        xmlchk = xml_parse_file(rfile)
 
     from ipi.inputs.simulation import InputSimulation
 
     simchk = InputSimulation()
     simchk.parse(xmlchk.fields[0][1])
-    sim = simchk.fetch()
-    if len(sim.syslist) > 1:
-        warning(
-            "Restart from checkpoint with "
-            + str(len(sim.syslist))
-            + " systems will fetch data from the first system."
-        )
-    rcell = sim.syslist[0].cell
-    rbeads = sim.syslist[0].beads
-    rmotion = sim.syslist[0].motion
-
-    return (rbeads, rcell, rmotion)
+    return simchk.fetch_checkpoint_state()
 
 
 def init_beads(

--- a/ipi/inputs/simulation.py
+++ b/ipi/inputs/simulation.py
@@ -12,7 +12,7 @@ from ipi.utils.units import *
 from ipi.utils.prng import *
 from ipi.utils.io import *
 from ipi.utils.io.inputs.io_xml import *
-from ipi.utils.messages import verbosity
+from ipi.utils.messages import verbosity, warning
 from ipi.engine.smotion import Smotion
 from ipi.inputs.prng import InputRandom
 from ipi.inputs.system import InputSystem, InputSysTemplate
@@ -384,3 +384,31 @@ frequency in your simulation to make i-PI faster. Use at your own risk!
         )
 
         return rsim
+
+    def fetch_checkpoint_state(self):
+        """Fetches the state needed to initialize from a checkpoint.
+
+        Unlike :meth:`fetch`, this intentionally does not construct a complete
+        simulation.  In particular, checkpoint force fields must not be
+        initialized when the checkpoint is used only by an initializer: they
+        are unrelated to the state being copied and can no longer be valid in
+        the current working directory.
+
+        Returns:
+           The beads, cell and motion objects of the first checkpoint system.
+        """
+
+        super(InputSimulation, self).fetch()
+
+        systems = [v for k, v in self.extra if k == "system"]
+        if len(systems) == 0:
+            raise ValueError("Checkpoint does not contain a system.")
+        if len(systems) > 1:
+            warning(
+                "Restart from checkpoint with "
+                + str(len(systems))
+                + " systems will fetch data from the first system."
+            )
+
+        system = systems[0]
+        return system.beads.fetch(), system.cell.fetch(), system.motion.fetch()

--- a/ipi_tests/unit_tests/engine/test_initializer.py
+++ b/ipi_tests/unit_tests/engine/test_initializer.py
@@ -112,8 +112,7 @@ def test_init_chk_skips_checkpoint_forcefields(tmp_path):
     """Checkpoint initialization reads state without constructing its PES."""
 
     checkpoint = tmp_path / "obsolete-forcefield.chk"
-    checkpoint.write_text(
-        """
+    checkpoint.write_text("""
 <simulation>
   <ffdirect name='obsolete'>
     <pes>custom</pes>
@@ -140,8 +139,7 @@ def test_init_chk_skips_checkpoint_forcefields(tmp_path):
     </cell>
   </system>
 </simulation>
-"""
-    )
+""")
 
     # The same checkpoint remains invalid as a full restart: FFDirect would
     # construct the custom PES and reject the missing pes_path.

--- a/ipi_tests/unit_tests/engine/test_initializer.py
+++ b/ipi_tests/unit_tests/engine/test_initializer.py
@@ -8,12 +8,16 @@ import os
 import numpy as np
 import tempfile as tmp
 import numpy.testing as npt
+from types import SimpleNamespace
 
 import ipi.engine.initializer as initializer
 import ipi.utils.mathtools as mt
 
-from ipi.utils.units import Elements
+from ipi.inputs.simulation import InputSimulation
+from ipi.utils.io.inputs.io_xml import xml_parse_string
+from ipi.utils.units import Elements, unit_to_internal
 from ipi.engine.atoms import Atoms
+from ipi.engine.beads import Beads
 from ipi.engine.cell import Cell
 
 
@@ -102,3 +106,74 @@ def test_init_file(create_xyz_sample_file):
         npt.assert_array_almost_equal(expected_ratoms[_ii].m, atoms.m, 5)
 
     npt.assert_array_almost_equal(expected_cell.h, ret[1].h, 5)
+
+
+def test_init_chk_skips_checkpoint_forcefields(tmp_path):
+    """Checkpoint initialization reads state without constructing its PES."""
+
+    checkpoint = tmp_path / "obsolete-forcefield.chk"
+    checkpoint.write_text(
+        """
+<simulation>
+  <ffdirect name='obsolete'>
+    <pes>custom</pes>
+  </ffdirect>
+  <system>
+    <forces><force forcefield='obsolete'/></forces>
+    <motion mode='dynamics'>
+      <dynamics mode='nve'>
+        <timestep units='femtosecond'>0.5</timestep>
+      </dynamics>
+    </motion>
+    <beads natoms='2' nbeads='2'>
+      <q shape='(2, 6)' units='angstrom'>
+        [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1]
+      </q>
+      <p shape='(2, 6)'>
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+      </p>
+      <m shape='(2)'>[1, 2]</m>
+      <names shape='(2)'>[H, He]</names>
+    </beads>
+    <cell shape='(3, 3)' units='angstrom'>
+      [2, 0, 0, 0, 3, 0, 0, 0, 4]
+    </cell>
+  </system>
+</simulation>
+"""
+    )
+
+    # The same checkpoint remains invalid as a full restart: FFDirect would
+    # construct the custom PES and reject the missing pes_path.
+    xmlchk = xml_parse_string(checkpoint.read_text())
+    full_restart = InputSimulation()
+    full_restart.parse(xmlchk.fields[0][1])
+    with pytest.raises(ValueError, match="pes_path"):
+        full_restart.fetch()
+
+    beads, cell, motion = initializer.init_chk(checkpoint)
+    q = np.arange(12, dtype=float).reshape(2, 6) / 10.0
+    npt.assert_allclose(beads.q, q * unit_to_internal("length", "angstrom"))
+    npt.assert_allclose(beads.p, np.arange(1, 13, dtype=float).reshape(2, 6))
+    npt.assert_allclose(
+        cell.h,
+        np.diag([2.0, 3.0, 4.0]) * unit_to_internal("length", "angstrom"),
+    )
+    assert motion.dt == pytest.approx(unit_to_internal("time", "femtosecond", 0.5))
+
+    # Exercise the regular <initialize> checkpoint code path as well.
+    target = SimpleNamespace(beads=Beads(0, 0), cell=Cell())
+    init = initializer.Initializer(
+        nbeads=2,
+        queue=[
+            ("positions", initializer.InitIndexed(value=str(checkpoint), mode="chk")),
+            ("masses", initializer.InitIndexed(value=str(checkpoint), mode="chk")),
+            ("labels", initializer.InitIndexed(value=str(checkpoint), mode="chk")),
+            ("momenta", initializer.InitIndexed(value=str(checkpoint), mode="chk")),
+            ("cell", initializer.InitFile(value=str(checkpoint), mode="chk")),
+        ],
+    )
+    init.init_stage1(target)
+    npt.assert_allclose(target.beads.q, beads.q)
+    npt.assert_allclose(target.beads.p, beads.p)
+    npt.assert_allclose(target.cell.h, cell.h)


### PR DESCRIPTION
## Summary

Fix checkpoint-based initialization (`<file mode='chk'>`) so it reads only the state required by the initializer:

- beads (positions, momenta, masses, labels)
- cell
- motion state

Checkpoint force fields are no longer constructed in this path. This prevents initialization from failing when an old checkpoint contains a stale or incompatible force-field configuration --> **good for backcompatibility**.

## Design

A new lightweight `InputSimulation.fetch_checkpoint_state()` method fetches the first system’s beads, cell, and motion directly from the parsed input objects.

Normal full-checkpoint restart behavior is unchanged: `InputSimulation.fetch()` still reconstructs all force fields.

## Tests

Added regression coverage for a checkpoint containing an `ffdirect` configuration that fails when instantiated:

- full checkpoint loading still raises the expected error;
- initialization from that checkpoint succeeds;
- positions, momenta, cell units, masses, labels, and motion state are transferred correctly.

Tested with:

```bash
.tox/unit/bin/pytest -q ipi_tests/unit_tests/engine/test_initializer.py
.tox/unit/bin/pytest -q ipi_tests/unit_tests/engine
```